### PR TITLE
Add Xbox achievements unlocked and total count sources with detailed …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,8 @@ target_sources(
     src/sources/xbox/achievement_name.c
     src/sources/xbox/achievement_description.c
     src/sources/xbox/achievement_icon.c
+    src/sources/xbox/achievements_unlocked_count.c
+    src/sources/xbox/achievements_total_count.c
     src/sources/common/text_source.c
     src/sources/common/image_source.c
     src/crypto/crypto.c

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ A cross-platform OBS Studio plugin that displays real-time Xbox Live achievement
 Once configured, the source will automatically display:
 - Using the **Xbox Cover** source, the cover of the game currently active on your Xbox One console will be shown
 - Using the **Xbox Gamerscore** source: your current gamerscore will be shown
-- TBD **Achievements Mode**: Current game's unlocked achievements count (e.g., "15 / 50 Achievements")
+- Using the **Xbox Achievements Unlocked Count** source: the number of achievements you've unlocked for the current game
+- Using the **Xbox Achievements Total Count** source: the total number of achievements available for the current game
 
 The plugin subscribes Xbox Live to get real-time updates of:
 - The currently active game
@@ -72,7 +73,9 @@ achievements-tracker-plugin/
 │   │   ├── log.c.in                    # Logging (CMake-configured)
 │   │   └── log.h                       # Logging API
 │   ├── drawing/
+│   │   ├── color.c/h                   # Color handling utilities
 │   │   ├── image.c/h                   # Image rendering helpers
+│   │   └── text.c/h                    # Text rendering helpers
 │   ├── encoding/
 │   │   └── base64.c/h                  # Base64 URL-safe encoding
 │   ├── io/
@@ -84,11 +87,25 @@ achievements-tracker-plugin/
 │   ├── oauth/
 │   │   ├── util.c/h                    # OAuth helpers (PKCE, code exchange)
 │   │   └── xbox-live.c/h               # Xbox Live OAuth & XSTS token flows
-│   ├── sources/xbox/                   # OBS source implementations
-│   │   ├── account.c/h                 # Xbox Account source
-│   │   ├── game_cover.c/h              # Xbox Game Cover source
-│   │   └── gamerscore.c/h              # Xbox Gamerscore source
+│   ├── sources/                        # OBS source implementations
+│   │   ├── common/                     # Shared source utilities
+│   │   │   ├── image_source.c/h        # Common image source functionality
+│   │   │   └── text_source.c/h         # Common text source functionality
+│   │   └── xbox/                       # Xbox-specific sources
+│   │       ├── account.c/h             # Xbox Account source (authentication)
+│   │       ├── achievement_description.c/h  # Achievement description text source
+│   │       ├── achievement_icon.c/h    # Achievement icon image source
+│   │       ├── achievement_name.c/h    # Achievement name text source
+│   │       ├── achievements_total_count.c/h  # Total achievements count text source
+│   │       ├── achievements_unlocked_count.c/h  # Unlocked achievements count text source
+│   │       ├── game_cover.c/h          # Xbox Game Cover image source
+│   │       ├── gamerpic.c/h            # Xbox Gamerpic image source
+│   │       ├── gamerscore.c/h          # Xbox Gamerscore text source
+│   │       └── gamertag.c/h            # Xbox Gamertag text source
+│   ├── system/
+│   │   └── font.c/h                    # System font discovery
 │   ├── text/
+│   │   ├── convert.c/h                 # Text conversion utilities
 │   │   └── parsers.c/h                 # Text/response parsing utilities
 │   ├── time/
 │   │   └── time.c/h                    # ISO-8601 timestamp parsing
@@ -99,10 +116,10 @@ achievements-tracker-plugin/
 │       ├── xbox_monitor.c/h            # Real-time activity monitoring
 │       └── xbox_session.c/h            # Session management
 ├── test/
+│   ├── test_convert.c                  # Text conversion tests
 │   ├── test_crypto.c                   # Cryptographic signing tests
 │   ├── test_encoder.c                  # Base64 encoding tests
 │   ├── test_parsers.c                  # Text parser tests
-│   ├── test_time.c                     # ISO-8601 parsing tests
 │   ├── test_types.c                    # Common types tests
 │   ├── test_xbox_session.c             # Xbox session tests
 │   ├── unity_config.h                  # Unity test framework config

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -211,6 +211,42 @@ typedef struct achievement_description_configuration {
 } achievement_description_configuration_t;
 
 /**
+ * @brief Configuration used by the achievements unlocked count overlay/renderer.
+ *
+ * Ownership:
+ * - Strings are treated as borrowed pointers unless otherwise documented by the
+ *   caller.
+ */
+typedef struct achievements_unlocked_count_configuration {
+    /** Font file path to load (e.g., "/Library/Fonts/SF-Pro.ttf"). */
+    const char  *font_path;
+    /** Font size in pixels (height passed to FreeType). */
+    uint32_t     font_size;
+    /** Packed RGBA color in 0xRRGGBBAA format. */
+    uint32_t     color;
+    /** Text alignment. */
+    text_align_t align;
+} achievements_unlocked_count_configuration_t;
+
+/**
+ * @brief Configuration used by the achievements total count overlay/renderer.
+ *
+ * Ownership:
+ * - Strings are treated as borrowed pointers unless otherwise documented by the
+ *   caller.
+ */
+typedef struct achievements_total_count_configuration {
+    /** Font file path to load (e.g., "/Library/Fonts/SF-Pro.ttf"). */
+    const char  *font_path;
+    /** Font size in pixels (height passed to FreeType). */
+    uint32_t     font_size;
+    /** Packed RGBA color in 0xRRGGBBAA format. */
+    uint32_t     color;
+    /** Text alignment. */
+    text_align_t align;
+} achievements_total_count_configuration_t;
+
+/**
  * @brief Dummy type to ensure OpenSSL public types are available to consumers.
  *
  * This header intentionally re-exports OpenSSL's @c EVP_PKEY type.

--- a/src/io/state.c
+++ b/src/io/state.c
@@ -48,6 +48,16 @@
 #define ACHIEVEMENT_DESCRIPTION_CONFIGURATION_FONT "source_achievement_description_font"
 #define ACHIEVEMENT_DESCRIPTION_CONFIGURATION_ALIGN "source_achievement_description_align"
 
+#define ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_COLOR "source_achievements_unlocked_count_color"
+#define ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_SIZE "source_achievements_unlocked_count_size"
+#define ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_FONT "source_achievements_unlocked_count_font"
+#define ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_ALIGN "source_achievements_unlocked_count_align"
+
+#define ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_COLOR "source_achievements_total_count_color"
+#define ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_SIZE "source_achievements_total_count_size"
+#define ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_FONT "source_achievements_total_count_font"
+#define ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_ALIGN "source_achievements_total_count_align"
+
 /**
  * @brief Global in-memory persisted state.
  *
@@ -450,6 +460,68 @@ achievement_description_configuration_t *state_get_achievement_description_confi
     configuration->font_size                               = size == 0 ? 12 : size;
     configuration->font_path                               = bstrdup(font_path);
     configuration->align                                   = align; // 0 = left (default), 1 = right
+
+    return configuration;
+}
+
+void state_set_achievements_unlocked_count_configuration(
+    const achievements_unlocked_count_configuration_t *configuration) {
+
+    if (!configuration) {
+        return;
+    }
+
+    obs_data_set_int(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_COLOR, configuration->color);
+    obs_data_set_int(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_SIZE, configuration->font_size);
+    obs_data_set_string(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_FONT, configuration->font_path);
+    obs_data_set_int(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_ALIGN, configuration->align);
+
+    save_state(g_state);
+}
+
+achievements_unlocked_count_configuration_t *state_get_achievements_unlocked_count_configuration() {
+
+    uint32_t    color     = (uint32_t)obs_data_get_int(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_COLOR);
+    uint32_t    size      = (uint32_t)obs_data_get_int(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_SIZE);
+    const char *font_path = obs_data_get_string(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_FONT);
+    uint32_t    align     = (uint32_t)obs_data_get_int(g_state, ACHIEVEMENTS_UNLOCKED_COUNT_CONFIGURATION_ALIGN);
+
+    achievements_unlocked_count_configuration_t *configuration =
+        bzalloc(sizeof(achievements_unlocked_count_configuration_t));
+    configuration->color     = color == 0 ? 0xFFFFFFFF : color;
+    configuration->font_size = size == 0 ? 48 : size;
+    configuration->font_path = bstrdup(font_path);
+    configuration->align     = align; // 0 = left (default), 1 = right
+
+    return configuration;
+}
+
+void state_set_achievements_total_count_configuration(const achievements_total_count_configuration_t *configuration) {
+
+    if (!configuration) {
+        return;
+    }
+
+    obs_data_set_int(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_COLOR, configuration->color);
+    obs_data_set_int(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_SIZE, configuration->font_size);
+    obs_data_set_string(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_FONT, configuration->font_path);
+    obs_data_set_int(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_ALIGN, configuration->align);
+
+    save_state(g_state);
+}
+
+achievements_total_count_configuration_t *state_get_achievements_total_count_configuration() {
+
+    uint32_t    color     = (uint32_t)obs_data_get_int(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_COLOR);
+    uint32_t    size      = (uint32_t)obs_data_get_int(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_SIZE);
+    const char *font_path = obs_data_get_string(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_FONT);
+    uint32_t    align     = (uint32_t)obs_data_get_int(g_state, ACHIEVEMENTS_TOTAL_COUNT_CONFIGURATION_ALIGN);
+
+    achievements_total_count_configuration_t *configuration = bzalloc(sizeof(achievements_total_count_configuration_t));
+    configuration->color                                    = color == 0 ? 0xFFFFFFFF : color;
+    configuration->font_size                                = size == 0 ? 48 : size;
+    configuration->font_path                                = bstrdup(font_path);
+    configuration->align                                    = align; // 0 = left (default), 1 = right
 
     return configuration;
 }

--- a/src/io/state.h
+++ b/src/io/state.h
@@ -185,6 +185,49 @@ void state_set_achievement_description_configuration(const achievement_descripti
 achievement_description_configuration_t *state_get_achievement_description_configuration();
 
 /**
+ * @brief Set the achievements unlocked count source configuration.
+ *
+ * Stores the configuration for the achievements unlocked count display source,
+ * including font path, text size, and color. The configuration is persisted to disk.
+ *
+ * @param configuration Configuration to store (may be NULL to clear).
+ */
+void state_set_achievements_unlocked_count_configuration(
+    const achievements_unlocked_count_configuration_t *configuration);
+
+/**
+ * @brief Get the currently stored achievements unlocked count source configuration.
+ *
+ * Retrieves the configuration with default values if none has been set:
+ * - Default color: 0xFFFFFFFF (white)
+ * - Default size: 48 pixels
+ *
+ * @return Newly allocated configuration structure. Caller must free it with bfree().
+ */
+achievements_unlocked_count_configuration_t *state_get_achievements_unlocked_count_configuration();
+
+/**
+ * @brief Set the achievements total count source configuration.
+ *
+ * Stores the configuration for the achievements total count display source,
+ * including font path, text size, and color. The configuration is persisted to disk.
+ *
+ * @param configuration Configuration to store (may be NULL to clear).
+ */
+void state_set_achievements_total_count_configuration(const achievements_total_count_configuration_t *configuration);
+
+/**
+ * @brief Get the currently stored achievements total count source configuration.
+ *
+ * Retrieves the configuration with default values if none has been set:
+ * - Default color: 0xFFFFFFFF (white)
+ * - Default size: 48 pixels
+ *
+ * @return Newly allocated configuration structure. Caller must free it with bfree().
+ */
+achievements_total_count_configuration_t *state_get_achievements_total_count_configuration();
+
+/**
  * @brief Clear all in-memory state (and typically any persisted state).
  *
  * After calling this, all getters are expected to return NULL until new values

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,8 @@
 #include "sources/xbox/achievement_name.h"
 #include "sources/xbox/achievement_description.h"
 #include "sources/xbox/achievement_icon.h"
+#include "sources/xbox/achievements_unlocked_count.h"
+#include "sources/xbox/achievements_total_count.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
@@ -27,6 +29,8 @@ bool obs_module_load(void) {
     xbox_achievement_name_source_register();
     xbox_achievement_description_source_register();
     xbox_achievement_icon_source_register();
+    xbox_achievements_unlocked_count_source_register();
+    xbox_achievements_total_count_source_register();
 
     obs_log(LOG_INFO, "plugin loaded successfully (version %s)", PLUGIN_VERSION);
 

--- a/src/sources/xbox/achievements_total_count.c
+++ b/src/sources/xbox/achievements_total_count.c
@@ -1,0 +1,227 @@
+#include "sources/xbox/achievements_total_count.h"
+
+/**
+ * @file achievements_total_count.c
+ * @brief OBS source that renders the total number of achievements for the current game.
+ *
+ * This source displays the total count of achievements available for the currently
+ * played Xbox game. The count is updated when the game changes.
+ *
+ * Data flow:
+ *  - The Xbox monitor notifies this module when connection state changes or
+ *    when the game changes.
+ *  - The module counts total achievements and stores the result in a global.
+ *  - During rendering, the count is formatted to text and rendered.
+ *
+ * Threading notes:
+ *  - Event handlers may be invoked from non-graphics threads.
+ *  - Texture creation must happen on the OBS graphics thread; this file lazily
+ *    initializes the texture in the video_render callback.
+ */
+
+#include "sources/common/text_source.h"
+#include "drawing/text.h"
+
+#include <graphics/graphics.h>
+#include <obs-module.h>
+#include <diagnostics/log.h>
+
+#include "common/achievement.h"
+#include "io/state.h"
+#include "oauth/xbox-live.h"
+#include "xbox/xbox_monitor.h"
+
+#define NO_FLIP 0
+
+static char            g_total_count[64];
+static bool            g_must_reload;
+static text_context_t *g_text_context;
+
+/**
+ * @brief Configuration for the total count display.
+ *
+ * Stored as a module-global pointer and initialized during
+ * xbox_achievements_total_count_source_register().
+ */
+static achievements_total_count_configuration_t *g_default_configuration;
+
+/**
+ * @brief Recompute and store the total achievements count.
+ */
+static void update_total_count(void) {
+    const achievement_t *achievements = get_current_game_achievements();
+
+    int total = count_achievements(achievements);
+
+    snprintf(g_total_count, sizeof(g_total_count), "/ %d", total);
+    g_must_reload = true;
+
+    obs_log(LOG_INFO, "Total achievements count: %d", total);
+}
+
+/**
+ * @brief Xbox monitor callback invoked when connection state changes.
+ *
+ * @param is_connected Whether the account is currently connected.
+ * @param error_message Optional error message if disconnected (ignored here).
+ */
+static void on_connection_changed(bool is_connected, const char *error_message) {
+    UNUSED_PARAMETER(error_message);
+
+    if (is_connected) {
+        update_total_count();
+    } else {
+        snprintf(g_total_count, sizeof(g_total_count), "0");
+        g_must_reload = true;
+    }
+}
+
+/**
+ * @brief Xbox monitor callback invoked when a new game is played.
+ *
+ * @param game Current game information.
+ */
+static void on_game_played(const game_t *game) {
+    UNUSED_PARAMETER(game);
+
+    update_total_count();
+}
+
+//  --------------------------------------------------------------------------------------------------------------------
+//	Source callbacks
+//  --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * @brief OBS callback creating a new source instance.
+ *
+ * @param settings Source settings (unused).
+ * @param source   OBS source instance.
+ * @return Newly allocated text_source_base_t.
+ */
+static void *on_source_create(obs_data_t *settings, obs_source_t *source) {
+    UNUSED_PARAMETER(settings);
+
+    return text_source_create(source, (source_size_t){200, 100});
+}
+
+/**
+ * @brief OBS callback destroying a source instance.
+ */
+static void on_source_destroy(void *data) {
+    text_source_base_t *source = data;
+
+    if (!source) {
+        return;
+    }
+
+    if (g_text_context) {
+        text_context_destroy(g_text_context);
+        g_text_context = NULL;
+    }
+
+    bfree(source);
+}
+
+/** @brief OBS callback returning the configured source width. */
+static uint32_t source_get_width(void *data) {
+    const text_source_base_t *s = data;
+    return s ? s->size.width : 0;
+}
+
+/** @brief OBS callback returning the configured source height. */
+static uint32_t source_get_height(void *data) {
+    const text_source_base_t *s = data;
+    return s ? s->size.height : 0;
+}
+
+/**
+ * @brief OBS callback invoked when settings change.
+ */
+static void on_source_update(void *data, obs_data_t *settings) {
+    UNUSED_PARAMETER(data);
+
+    text_source_update_properties(settings, (text_source_config_t *)g_default_configuration, &g_must_reload);
+
+    state_set_achievements_total_count_configuration(g_default_configuration);
+}
+
+/**
+ * @brief OBS callback to render the total count.
+ *
+ * @param data   Source instance data.
+ * @param effect Effect to use when rendering. If NULL, OBS default effect is used.
+ */
+static void on_source_video_render(void *data, gs_effect_t *effect) {
+    text_source_base_t *source = data;
+
+    if (!source) {
+        return;
+    }
+
+    if (!text_source_reload_if_needed(&g_text_context,
+                                      &g_must_reload,
+                                      (const text_source_config_t *)g_default_configuration,
+                                      source,
+                                      g_total_count)) {
+        return;
+    }
+
+    text_source_render_unscaled(g_text_context, effect);
+}
+
+/**
+ * @brief OBS callback constructing the properties UI.
+ */
+static obs_properties_t *source_get_properties(void *data) {
+    UNUSED_PARAMETER(data);
+
+    obs_properties_t *p = obs_properties_create();
+    text_source_add_properties(p);
+
+    return p;
+}
+
+/** @brief OBS callback returning the display name for this source type. */
+static const char *source_get_name(void *unused) {
+    UNUSED_PARAMETER(unused);
+
+    return "Xbox Achievements Total Count";
+}
+
+/**
+ * @brief obs_source_info describing the Xbox Achievements Total Count source.
+ */
+static struct obs_source_info xbox_achievements_total_count_source = {
+    .id             = "xbox_achievements_total_count_source",
+    .type           = OBS_SOURCE_TYPE_INPUT,
+    .output_flags   = OBS_SOURCE_VIDEO,
+    .get_name       = source_get_name,
+    .create         = on_source_create,
+    .destroy        = on_source_destroy,
+    .update         = on_source_update,
+    .get_properties = source_get_properties,
+    .get_width      = source_get_width,
+    .get_height     = source_get_height,
+    .video_tick     = NULL,
+    .video_render   = on_source_video_render,
+};
+
+/**
+ * @brief Get the obs_source_info for registration.
+ */
+static const struct obs_source_info *xbox_source_get(void) {
+    return &xbox_achievements_total_count_source;
+}
+
+//  --------------------------------------------------------------------------------------------------------------------
+//	Public functions
+//  --------------------------------------------------------------------------------------------------------------------
+
+void xbox_achievements_total_count_source_register(void) {
+    g_default_configuration = state_get_achievements_total_count_configuration();
+
+    obs_register_source(xbox_source_get());
+
+    xbox_subscribe_connected_changed(&on_connection_changed);
+    xbox_subscribe_game_played(&on_game_played);
+}

--- a/src/sources/xbox/achievements_total_count.h
+++ b/src/sources/xbox/achievements_total_count.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file achievements_total_count.h
+ * @brief OBS source type that renders the total number of achievements for the current game.
+ *
+ * This module registers an OBS source that displays the total number of achievements
+ * available for the currently played Xbox game.
+ */
+
+/**
+ * @brief Register the "Xbox Achievements Total Count" source with OBS.
+ *
+ * Call once during plugin/module initialization.
+ */
+void xbox_achievements_total_count_source_register(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/sources/xbox/achievements_unlocked_count.c
+++ b/src/sources/xbox/achievements_unlocked_count.c
@@ -1,0 +1,257 @@
+#include "sources/xbox/achievements_unlocked_count.h"
+
+/**
+ * @file achievements_unlocked_count.c
+ * @brief OBS source that renders the number of unlocked achievements for the current game.
+ *
+ * This source displays the count of unlocked achievements for the currently played
+ * Xbox game. The count is updated when achievements are unlocked or when the game changes.
+ *
+ * Data flow:
+ *  - The Xbox monitor notifies this module when connection state changes,
+ *    game changes, or achievement progress updates.
+ *  - The module counts unlocked achievements and stores the result in a global.
+ *  - During rendering, the count is formatted to text and rendered.
+ *
+ * Threading notes:
+ *  - Event handlers may be invoked from non-graphics threads.
+ *  - Texture creation must happen on the OBS graphics thread; this file lazily
+ *    initializes the texture in the video_render callback.
+ */
+
+#include "sources/common/text_source.h"
+#include "drawing/text.h"
+
+#include <graphics/graphics.h>
+#include <obs-module.h>
+#include <diagnostics/log.h>
+
+#include "common/achievement.h"
+#include "io/state.h"
+#include "oauth/xbox-live.h"
+#include "xbox/xbox_monitor.h"
+
+#define NO_FLIP 0
+
+static char            g_unlocked_count[64];
+static bool            g_must_reload;
+static text_context_t *g_text_context;
+
+/**
+ * @brief Configuration for the unlocked count display.
+ *
+ * Stored as a module-global pointer and initialized during
+ * xbox_achievements_unlocked_count_source_register().
+ */
+static achievements_unlocked_count_configuration_t *g_default_configuration;
+
+/**
+ * @brief Count unlocked achievements from an achievement list.
+ *
+ * @param achievements Head of the achievements list.
+ * @return Number of unlocked achievements (those with unlocked_timestamp > 0).
+ */
+static int count_unlocked_achievements(const achievement_t *achievements) {
+    int count = 0;
+    for (const achievement_t *a = achievements; a != NULL; a = a->next) {
+        if (a->unlocked_timestamp > 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/**
+ * @brief Recompute and store the unlocked achievements count.
+ */
+static void update_unlocked_count(void) {
+    const achievement_t *achievements = get_current_game_achievements();
+
+    int unlocked = count_unlocked_achievements(achievements);
+
+    snprintf(g_unlocked_count, sizeof(g_unlocked_count), "%d", unlocked);
+    g_must_reload = true;
+
+    obs_log(LOG_INFO, "Unlocked achievements count: %d", unlocked);
+}
+
+/**
+ * @brief Xbox monitor callback invoked when connection state changes.
+ *
+ * @param is_connected Whether the account is currently connected.
+ * @param error_message Optional error message if disconnected (ignored here).
+ */
+static void on_connection_changed(bool is_connected, const char *error_message) {
+    UNUSED_PARAMETER(error_message);
+
+    if (is_connected) {
+        update_unlocked_count();
+    } else {
+        snprintf(g_unlocked_count, sizeof(g_unlocked_count), "0");
+        g_must_reload = true;
+    }
+}
+
+/**
+ * @brief Xbox monitor callback invoked when achievements progress.
+ *
+ * @param gamerscore Updated gamerscore snapshot (unused).
+ * @param progress   Achievement progress details (unused).
+ */
+static void on_achievements_progressed(const gamerscore_t *gamerscore, const achievement_progress_t *progress) {
+    UNUSED_PARAMETER(gamerscore);
+    UNUSED_PARAMETER(progress);
+
+    update_unlocked_count();
+}
+
+/**
+ * @brief Xbox monitor callback invoked when a new game is played.
+ *
+ * @param game Current game information.
+ */
+static void on_game_played(const game_t *game) {
+    UNUSED_PARAMETER(game);
+
+    update_unlocked_count();
+}
+
+//  --------------------------------------------------------------------------------------------------------------------
+//	Source callbacks
+//  --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * @brief OBS callback creating a new source instance.
+ *
+ * @param settings Source settings (unused).
+ * @param source   OBS source instance.
+ * @return Newly allocated text_source_base_t.
+ */
+static void *on_source_create(obs_data_t *settings, obs_source_t *source) {
+    UNUSED_PARAMETER(settings);
+
+    return text_source_create(source, (source_size_t){200, 100});
+}
+
+/**
+ * @brief OBS callback destroying a source instance.
+ */
+static void on_source_destroy(void *data) {
+    text_source_base_t *source = data;
+
+    if (!source) {
+        return;
+    }
+
+    if (g_text_context) {
+        text_context_destroy(g_text_context);
+        g_text_context = NULL;
+    }
+
+    bfree(source);
+}
+
+/** @brief OBS callback returning the configured source width. */
+static uint32_t source_get_width(void *data) {
+    const text_source_base_t *s = data;
+    return s ? s->size.width : 0;
+}
+
+/** @brief OBS callback returning the configured source height. */
+static uint32_t source_get_height(void *data) {
+    const text_source_base_t *s = data;
+    return s ? s->size.height : 0;
+}
+
+/**
+ * @brief OBS callback invoked when settings change.
+ */
+static void on_source_update(void *data, obs_data_t *settings) {
+    UNUSED_PARAMETER(data);
+
+    text_source_update_properties(settings, (text_source_config_t *)g_default_configuration, &g_must_reload);
+
+    state_set_achievements_unlocked_count_configuration(g_default_configuration);
+}
+
+/**
+ * @brief OBS callback to render the unlocked count.
+ *
+ * @param data   Source instance data.
+ * @param effect Effect to use when rendering. If NULL, OBS default effect is used.
+ */
+static void on_source_video_render(void *data, gs_effect_t *effect) {
+    text_source_base_t *source = data;
+
+    if (!source) {
+        return;
+    }
+
+    if (!text_source_reload_if_needed(&g_text_context,
+                                      &g_must_reload,
+                                      (const text_source_config_t *)g_default_configuration,
+                                      source,
+                                      g_unlocked_count)) {
+        return;
+    }
+
+    text_source_render_unscaled(g_text_context, effect);
+}
+
+/**
+ * @brief OBS callback constructing the properties UI.
+ */
+static obs_properties_t *source_get_properties(void *data) {
+    UNUSED_PARAMETER(data);
+
+    obs_properties_t *p = obs_properties_create();
+    text_source_add_properties(p);
+
+    return p;
+}
+
+/** @brief OBS callback returning the display name for this source type. */
+static const char *source_get_name(void *unused) {
+    UNUSED_PARAMETER(unused);
+
+    return "Xbox Achievements Unlocked Count";
+}
+
+/**
+ * @brief obs_source_info describing the Xbox Achievements Unlocked Count source.
+ */
+static struct obs_source_info xbox_achievements_unlocked_count_source = {
+    .id             = "xbox_achievements_unlocked_count_source",
+    .type           = OBS_SOURCE_TYPE_INPUT,
+    .output_flags   = OBS_SOURCE_VIDEO,
+    .get_name       = source_get_name,
+    .create         = on_source_create,
+    .destroy        = on_source_destroy,
+    .update         = on_source_update,
+    .get_properties = source_get_properties,
+    .get_width      = source_get_width,
+    .get_height     = source_get_height,
+    .video_tick     = NULL,
+    .video_render   = on_source_video_render,
+};
+
+/**
+ * @brief Get the obs_source_info for registration.
+ */
+static const struct obs_source_info *xbox_source_get(void) {
+    return &xbox_achievements_unlocked_count_source;
+}
+
+//  --------------------------------------------------------------------------------------------------------------------
+//	Public functions
+//  --------------------------------------------------------------------------------------------------------------------
+
+void xbox_achievements_unlocked_count_source_register(void) {
+    g_default_configuration = state_get_achievements_unlocked_count_configuration();
+
+    obs_register_source(xbox_source_get());
+
+    xbox_subscribe_connected_changed(&on_connection_changed);
+    xbox_subscribe_achievements_progressed(&on_achievements_progressed);
+    xbox_subscribe_game_played(&on_game_played);
+}

--- a/src/sources/xbox/achievements_unlocked_count.h
+++ b/src/sources/xbox/achievements_unlocked_count.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file achievements_unlocked_count.h
+ * @brief OBS source type that renders the number of unlocked achievements for the current game.
+ *
+ * This module registers an OBS source that displays how many achievements have been
+ * unlocked for the currently played Xbox game.
+ */
+
+/**
+ * @brief Register the "Xbox Achievements Unlocked Count" source with OBS.
+ *
+ * Call once during plugin/module initialization.
+ */
+void xbox_achievements_unlocked_count_source_register(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This pull request adds support for two new OBS sources that display Xbox achievement counts: the number of achievements unlocked and the total number of achievements for the current game. It also introduces configuration structures and persistent state management for these sources, updates documentation, and registers the new sources during plugin initialization.

New Xbox Achievement Count Sources:

* Added `achievements_unlocked_count.c/h` and `achievements_total_count.c/h` sources, which display the unlocked and total achievement counts for the current game in OBS.
* Registered the new sources in the plugin initialization (`src/main.c`) so they are available when the plugin loads.

Configuration and State Management:

* Introduced configuration structs for both sources (`achievements_unlocked_count_configuration_t` and `achievements_total_count_configuration_t`) in `src/common/types.h`.
* Added persistent state management functions for these configurations in `src/io/state.c` and `src/io/state.h`, allowing saving and loading of font, color, size, and alignment settings.

Documentation and Project Structure:

* Updated `README.md` to document the new sources, their purpose, and the new directory structure for source files and utilities.