### PR TITLE
Support for MSA token refresh

### DIFF
--- a/src/sources/xbox/account.c
+++ b/src/sources/xbox/account.c
@@ -232,12 +232,12 @@ static obs_properties_t *source_get_properties(void *data) {
             snprintf(game_played, sizeof(game_played), "Playing %s (%s)", game->title, game->id);
             obs_properties_add_text(p, "game_played", game_played, OBS_TEXT_INFO);
         }
+
+        obs_properties_add_button(p, "sign_out_xbox", "Sign out from Xbox", &on_sign_out_clicked);
+    } else {
+        obs_properties_add_text(p, "disconnected_status_info", "You are not connected.", OBS_TEXT_INFO);
+        obs_properties_add_button(p, "sign_in_xbox", "Sign in with Xbox", &on_sign_in_xbox_clicked);
     }
-    obs_properties_add_button(p, "sign_out_xbox", "Sign out from Xbox", &on_sign_out_clicked);
-    //}// else {
-    obs_properties_add_text(p, "disconnected_status_info", "You are not connected.", OBS_TEXT_INFO);
-    obs_properties_add_button(p, "sign_in_xbox", "Sign in with Xbox", &on_sign_in_xbox_clicked);
-    //}
 
     free_memory((void **)&xbox_identity);
 


### PR DESCRIPTION
This pull request improves the logic for displaying Xbox account connection status in the OBS properties panel. The main change ensures that the correct UI elements are shown based on whether the user is connected or not.

UI logic improvements:

* Corrected the conditional structure in `source_get_properties` in `account.c` so that sign-in and sign-out options, as well as status messages, are displayed appropriately depending on the user's Xbox connection status.