### PR TITLE
[FEAT-14] - Support for Windows and Linux

### DIFF
--- a/src/net/browser/browser.c
+++ b/src/net/browser/browser.c
@@ -27,9 +27,8 @@ bool open_url(const char *url) {
 
 #else
 
-
     char cmd[2048];
-    int n = 0;
+    int  n = 0;
 
 #ifdef __APPLE__
 


### PR DESCRIPTION
This pull request adds Windows support to the `open_url` function in `browser.c`, making the function cross-platform across Windows, macOS, and Linux. The implementation now uses the appropriate system call or command for each operating system to open a URL in the default browser.

Platform support improvements:

* Added Windows support using `ShellExecuteA` to open URLs in the default browser.
* Refactored platform checks to use `open` on macOS and `xdg-open` on Linux, ensuring the correct command is used for each OS.
* Removed the fallback warning for unsupported operating systems, as all major platforms are now supported.