### PR TITLE
[FEAT] - Support for Linux installation

### DIFF
--- a/.github/scripts/package-ubuntu
+++ b/.github/scripts/package-ubuntu
@@ -169,20 +169,26 @@ ${_usage_host:-}"
   popd
 
   if (( package )) {
-    log_group "Packaging ${product_name}..."
+    log_group "Packaging ${product_name} (.deb)..."
     pushd ${project_root}
     cmake --build build_${target##*-} --config ${config} -t package ${cmake_args}
     popd
-  } else {
-    log_group "Archiving ${product_name}..."
-    local output_name="${product_name}-${product_version}-${target##*-}-ubuntu-gnu"
-    local _tarflags='cJf'
-    if (( _loglevel > 1 || ${+CI} )) _tarflags="v${_tarflags}"
-
-    pushd ${project_root}/release/${config}
-    XZ_OPT=-T0 tar "-${_tarflags}" ${project_root}/release/${output_name}.tar.xz (lib|share)
-    popd
   }
+
+  # Always produce a portable .zip containing the lib/ and share/ trees so users
+  # can install manually without a package manager.
+  log_group "Archiving ${product_name} (.zip)..."
+  local output_name="${product_name}-${product_version}-${target##*-}"
+  local _tarflags='cJf'
+  if (( _loglevel > 1 || ${+CI} )) _tarflags="v${_tarflags}"
+
+  pushd ${project_root}/release/${config}
+  # .tar.xz (kept for backwards-compat / existing CI consumers)
+  XZ_OPT=-T0 tar "-${_tarflags}" ${project_root}/release/${output_name}.tar.xz (lib|share)
+  # .zip — portable archive for manual installation
+  zip -r ${project_root}/release/${output_name}.zip (lib|share)
+  popd
+
   log_group
 }
 

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -40,12 +40,47 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
 
   sudo apt-get install ${apt_args} \
     build-essential \
+    cmake \
     libgles2-mesa-dev \
     libsimde-dev \
-    libwebsockets-dev \
+    libssl-dev \
     libcap-dev \
     obs-studio \
     zip
+
+  # Build libwebsockets from source with -fPIC so it can be statically linked
+  # into our plugin .so.  The distro package (libwebsockets-dev) ships a .a
+  # compiled WITHOUT -fPIC, which causes a link error when embedded in a shared
+  # object ("relocation can not be used when making a shared object; recompile
+  # with -fPIC").  Building from source is the only reliable fix.
+  log_group 'Building libwebsockets from source (PIC static)...'
+  local lws_version='4.3.3'
+  local lws_build_dir="/tmp/lws-build"
+  mkdir -p ${lws_build_dir}
+  pushd ${lws_build_dir}
+  curl -fsSL "https://github.com/warmcat/libwebsockets/archive/refs/tags/v${lws_version}.tar.gz" \
+    | tar -xz --strip-components=1
+  cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DLWS_WITH_SHARED=OFF \
+    -DLWS_WITH_STATIC=ON \
+    -DLWS_WITH_SSL=ON \
+    -DLWS_WITH_LIBUV=OFF \
+    -DLWS_WITH_LIBEVENT=OFF \
+    -DLWS_WITH_GLIB=OFF \
+    -DLWS_WITHOUT_TESTAPPS=ON \
+    -DLWS_WITHOUT_TEST_SERVER=ON \
+    -DLWS_WITHOUT_TEST_PING=ON \
+    -DLWS_WITHOUT_TEST_CLIENT=ON \
+    -DCMAKE_INSTALL_PREFIX=/usr/local
+  cmake --build build --parallel
+  sudo cmake --install build
+  # Update the linker cache so /usr/local/lib is searched before /usr/lib
+  sudo ldconfig
+  popd
+  rm -rf ${lws_build_dir}
+  log_group
 
   local -a _qt_packages=()
 
@@ -67,3 +102,5 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
   sudo apt-get install ${apt_args} ${_qt_packages}
   log_group
 }
+
+popd

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -23,6 +23,32 @@ if (( _loglevel == 0 )) apt_args+=(--quiet)
 if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
   log_group 'Installing obs-studio build dependencies...'
 
+  local buildspec_file="${project_root}/buildspec.json"
+  local obs_version
+  obs_version="$(jq -r '.dependencies["obs-studio"].version // empty' "${buildspec_file}")"
+  if [[ -z ${obs_version} || ${obs_version} == null ]] {
+    log_error "Unable to determine the OBS Studio version from ${buildspec_file}."
+    return 2
+  }
+  obs_version=${obs_version#v}
+
+  _resolve_obs_package_version() {
+    local package_name="${1}"
+    local version_prefix="${2}"
+
+    apt-cache madison "${package_name}" \
+      | awk -v prefix="${version_prefix}" '
+          $3 == prefix ||
+          index($3, prefix "~") == 1 ||
+          index($3, prefix "-") == 1 ||
+          index($3, prefix "+") == 1 ||
+          index($3, prefix ":") == 1 {
+            print $3
+            exit
+          }
+        '
+  }
+
   local suffix
   if [[ ${CPUTYPE} != "${target##*-}" ]] {
     local -A arch_mappings=(
@@ -38,6 +64,16 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
   sudo add-apt-repository --yes ppa:obsproject/obs-studio
   sudo apt update
 
+  local obs_package_version
+  obs_package_version="$(_resolve_obs_package_version obs-studio "${obs_version}")"
+  if [[ -z ${obs_package_version} ]] {
+    log_error "Could not find an obs-studio package matching OBS ${obs_version}. Refusing to build against a newer libobs ABI."
+    apt-cache madison obs-studio || true
+    return 2
+  }
+
+  log_info "Using obs-studio package version ${obs_package_version} (from buildspec OBS ${obs_version})"
+
   sudo apt-get install ${apt_args} \
     build-essential \
     cmake \
@@ -45,7 +81,7 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
     libsimde-dev \
     libssl-dev \
     libcap-dev \
-    obs-studio \
+    obs-studio=${obs_package_version} \
     zip
 
   # Build libwebsockets from source with -fPIC so it can be statically linked

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -23,32 +23,6 @@ if (( _loglevel == 0 )) apt_args+=(--quiet)
 if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
   log_group 'Installing obs-studio build dependencies...'
 
-  local buildspec_file="${project_root}/buildspec.json"
-  local obs_version
-  obs_version="$(jq -r '.dependencies["obs-studio"].version // empty' "${buildspec_file}")"
-  if [[ -z ${obs_version} || ${obs_version} == null ]] {
-    log_error "Unable to determine the OBS Studio version from ${buildspec_file}."
-    return 2
-  }
-  obs_version=${obs_version#v}
-
-  _resolve_obs_package_version() {
-    local package_name="${1}"
-    local version_prefix="${2}"
-
-    apt-cache madison "${package_name}" \
-      | awk -v prefix="${version_prefix}" '
-          $3 == prefix ||
-          index($3, prefix "~") == 1 ||
-          index($3, prefix "-") == 1 ||
-          index($3, prefix "+") == 1 ||
-          index($3, prefix ":") == 1 {
-            print $3
-            exit
-          }
-        '
-  }
-
   local suffix
   if [[ ${CPUTYPE} != "${target##*-}" ]] {
     local -A arch_mappings=(
@@ -61,27 +35,31 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
     sudo apt-get install ${apt_args} gcc-${${target##*-}//_/-}-linux-gnu g++-${${target##*-}//_/-}-linux-gnu
   }
 
-  sudo add-apt-repository --yes ppa:obsproject/obs-studio
   sudo apt update
-
-  local obs_package_version
-  obs_package_version="$(_resolve_obs_package_version obs-studio "${obs_version}")"
-  if [[ -z ${obs_package_version} ]] {
-    log_error "Could not find an obs-studio package matching OBS ${obs_version}. Refusing to build against a newer libobs ABI."
-    apt-cache madison obs-studio || true
-    return 2
-  }
-
-  log_info "Using obs-studio package version ${obs_package_version} (from buildspec OBS ${obs_version})"
 
   sudo apt-get install ${apt_args} \
     build-essential \
     cmake \
+    libavcodec-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libdrm-dev \
     libgles2-mesa-dev \
-    libsimde-dev \
-    libssl-dev \
+    libjansson-dev \
     libcap-dev \
-    obs-studio=${obs_package_version} \
+    libpulse-dev \
+    libsimde-dev \
+    libswresample-dev \
+    libswscale-dev \
+    libx11-dev \
+    libx11-xcb-dev \
+    libxcb1-dev \
+    libxcb-xinput-dev \
+    libxkbcommon-dev \
+    libssl-dev \
+    uthash-dev \
+    uuid-dev \
+    zlib1g-dev \
     zip
 
   # Build libwebsockets from source with -fPIC so it can be statically linked

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -43,6 +43,7 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
     libgles2-mesa-dev \
     libsimde-dev \
     libwebsockets-dev \
+    libcap-dev \
     obs-studio \
     zip
 

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -43,7 +43,8 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
     libgles2-mesa-dev \
     libsimde-dev \
     libwebsockets-dev \
-    obs-studio
+    obs-studio \
+    zip
 
   local -a _qt_packages=()
 

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -40,6 +40,7 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
   sudo apt-get install ${apt_args} \
     build-essential \
     cmake \
+    extra-cmake-modules \
     libavcodec-dev \
     libavformat-dev \
     libavutil-dev \

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -386,7 +386,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.check-event.outputs.pluginInternalName }}-${{ needs.check-event.outputs.pluginVersion }}-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ needs.check-event.outputs.pluginInternalName }}-${{ needs.check-event.outputs.pluginVersion }}-x86_64*.*
+          path: |
+            ${{ github.workspace }}/release/${{ needs.check-event.outputs.pluginInternalName }}-${{ needs.check-event.outputs.pluginVersion }}-x86_64.zip
+            ${{ github.workspace }}/release/${{ needs.check-event.outputs.pluginInternalName }}-${{ needs.check-event.outputs.pluginVersion }}-x86_64.tar.xz
+            ${{ github.workspace }}/release/${{ needs.check-event.outputs.pluginInternalName }}-${{ needs.check-event.outputs.pluginVersion }}-x86_64*.deb
 
       - name: Upload debug symbol artifacts 🪲
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -77,7 +77,7 @@ jobs:
             'windows-x64;zip|exe'
             'windows-arm64;zip|exe'
             'macos-universal;tar.xz|pkg'
-            'ubuntu-24.04-x86_64;tar.xz|deb|ddeb'
+            'ubuntu-24.04-x86_64;zip|tar.xz|deb|ddeb'
             'sources;tar.xz'
           )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,7 @@ if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
   # The from-source / vcpkg builds create Libwebsockets::websockets (namespaced),
   # older configs may use websockets or websockets_shared.
   set(_lws_target "")
-  foreach(_candidate IN ITEMS
-      Libwebsockets::websockets
-      websockets_shared
-      websockets)
+  foreach(_candidate IN ITEMS Libwebsockets::websockets websockets_shared websockets)
     if(TARGET ${_candidate})
       set(_lws_target ${_candidate})
       break()
@@ -148,7 +145,10 @@ if(NOT LIBWEBSOCKETS_LINKED)
   message(WARNING "libwebsockets not found. Xbox Live RTA monitoring will be disabled.")
   message(WARNING "To enable RTA monitoring, install libwebsockets:")
   message(WARNING "  macOS:   brew install libwebsockets")
-  message(WARNING "  Linux:   built from source with -fPIC by setup_ubuntu (see .github/scripts/utils.zsh/setup_ubuntu)")
+  message(
+    WARNING
+    "  Linux:   built from source with -fPIC by setup_ubuntu (see .github/scripts/utils.zsh/setup_ubuntu)"
+  )
   message(WARNING "  Windows: vcpkg install libwebsockets:x64-windows-static (or arm64-windows-static)")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,20 +63,48 @@ find_package(CURL REQUIRED)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE CURL::libcurl)
 
 # WebSocket client for Xbox Live RTA monitoring
-# Try multiple methods to find libwebsockets.
+#
+# IMPORTANT (Linux): the plugin is a .so loaded at runtime by OBS.  OBS does
+# NOT bundle libwebsockets, so linking it dynamically produces a hard runtime
+# dependency on libwebsockets.so that the end-user must satisfy separately.
+# To avoid that, we always prefer the static archive (libwebsockets.a) on Linux.
+#
 # LIBWEBSOCKETS_LINKED tracks whether we actually linked the library AND defined
-# HAVE_LIBWEBSOCKETS. LIBWEBSOCKETS_FOUND only records that the package was
-# located; the two are kept separate so that a successful find_package() that
-# doesn't produce a usable target doesn't suppress the pkg-config fallback.
+# HAVE_LIBWEBSOCKETS.  It is kept separate from the "package was found" flag so
+# that a successful find_package() that doesn't produce a usable target doesn't
+# suppress the pkg-config fallback.
 set(LIBWEBSOCKETS_LINKED FALSE)
+
+# Helper: given a target, return the path to its static archive on Linux.
+# If the target already points to a .a, returns it directly.
+# Otherwise, looks for a libwebsockets.a beside the shared library.
+function(_lws_resolve_static_lib out_var imported_target)
+  set(_result "")
+  if(UNIX AND NOT APPLE)
+    get_target_property(_loc ${imported_target} IMPORTED_LOCATION)
+    if(NOT _loc)
+      get_target_property(_loc ${imported_target} LOCATION)
+    endif()
+    if(_loc MATCHES "\\.a$")
+      set(_result "${_loc}")
+    elseif(_loc)
+      # e.g. /usr/lib/x86_64-linux-gnu/libwebsockets.so  →  look for .a alongside
+      get_filename_component(_dir  "${_loc}" DIRECTORY)
+      get_filename_component(_name "${_loc}" NAME_WE)   # libwebsockets
+      if(EXISTS "${_dir}/${_name}.a")
+        set(_result "${_dir}/${_name}.a")
+      endif()
+    endif()
+  endif()
+  set(${out_var} "${_result}" PARENT_SCOPE)
+endfunction()
 
 # Method 1: Try CMake's find_package
 find_package(Libwebsockets QUIET)
 if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
   # Probe all known target names produced by various libwebsockets CMake configs.
-  # Ubuntu's libwebsockets-dev typically installs a config that creates
-  # Libwebsockets::websockets (namespaced), while vcpkg/source builds may
-  # create websockets or websockets_shared.
+  # Ubuntu's libwebsockets-dev creates Libwebsockets::websockets (namespaced),
+  # while vcpkg/source builds may create websockets or websockets_shared.
   set(_lws_target "")
   foreach(_candidate IN ITEMS
       Libwebsockets::websockets
@@ -89,7 +117,20 @@ if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
   endforeach()
 
   if(_lws_target)
-    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${_lws_target})
+    if(UNIX AND NOT APPLE)
+      # On Linux prefer the static archive to avoid a runtime .so dependency.
+      _lws_resolve_static_lib(_lws_static_lib ${_lws_target})
+      if(_lws_static_lib)
+        message(STATUS "Found libwebsockets via CMake package — linking static archive: ${_lws_static_lib}")
+        target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
+        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE "${_lws_static_lib}")
+      else()
+        message(WARNING "libwebsockets static archive (.a) not found beside shared lib — falling back to dynamic link.")
+        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${_lws_target})
+      endif()
+    else()
+      target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${_lws_target})
+    endif()
     # Static libwebsockets on Windows requires Winsock; link it explicitly since
     # the imported target does not always propagate it as a dependency.
     if(WIN32)
@@ -97,7 +138,9 @@ if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
     endif()
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
     set(LIBWEBSOCKETS_LINKED TRUE)
-    message(STATUS "Found libwebsockets via CMake package (target: ${_lws_target})")
+    if(NOT (UNIX AND NOT APPLE))
+      message(STATUS "Found libwebsockets via CMake package (target: ${_lws_target})")
+    endif()
   endif()
 endif()
 
@@ -105,20 +148,64 @@ endif()
 if(NOT LIBWEBSOCKETS_LINKED)
   find_package(PkgConfig QUIET)
   if(PkgConfig_FOUND)
-    pkg_check_modules(LIBWEBSOCKETS QUIET libwebsockets)
-    if(LIBWEBSOCKETS_FOUND)
-      target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
-      target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_LIBRARIES})
-      target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
-      set(LIBWEBSOCKETS_LINKED TRUE)
-      message(STATUS "Found libwebsockets via pkg-config")
+    if(UNIX AND NOT APPLE)
+      # Use STATIC so pkg_check_modules also returns transitive dependencies
+      # (libcap, libssl, …) that the static archive requires at link time.
+      pkg_check_modules(LIBWEBSOCKETS QUIET STATIC libwebsockets)
+      if(LIBWEBSOCKETS_FOUND)
+        # Try to locate the static archive (.a) from the library search dirs.
+        set(_lws_static_lib "")
+        foreach(_lws_lib_dir IN LISTS LIBWEBSOCKETS_LIBRARY_DIRS)
+          if(EXISTS "${_lws_lib_dir}/libwebsockets.a")
+            set(_lws_static_lib "${_lws_lib_dir}/libwebsockets.a")
+            break()
+          endif()
+        endforeach()
+        # Also search well-known system lib dirs if not found above.
+        if(NOT _lws_static_lib)
+          foreach(_sys_dir IN ITEMS
+              /usr/lib/x86_64-linux-gnu
+              /usr/lib/aarch64-linux-gnu
+              /usr/lib
+              /usr/local/lib)
+            if(EXISTS "${_sys_dir}/libwebsockets.a")
+              set(_lws_static_lib "${_sys_dir}/libwebsockets.a")
+              break()
+            endif()
+          endforeach()
+        endif()
+
+        target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
+        if(_lws_static_lib)
+          message(STATUS "Found libwebsockets via pkg-config — linking static archive: ${_lws_static_lib}")
+          # Link the .a directly, then the transitive static deps reported by
+          # pkg-config (libcap, libssl, etc.).  CMake deduplicates automatically.
+          target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+            "${_lws_static_lib}"
+            ${LIBWEBSOCKETS_STATIC_LIBRARIES}
+          )
+        else()
+          message(WARNING "libwebsockets static archive (.a) not found — falling back to dynamic link.")
+          target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_LIBRARIES})
+        endif()
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
+        set(LIBWEBSOCKETS_LINKED TRUE)
+      endif()
+    else()
+      pkg_check_modules(LIBWEBSOCKETS QUIET libwebsockets)
+      if(LIBWEBSOCKETS_FOUND)
+        target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
+        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_LIBRARIES})
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
+        set(LIBWEBSOCKETS_LINKED TRUE)
+        message(STATUS "Found libwebsockets via pkg-config")
+      endif()
     endif()
   endif()
 endif()
 
-# Method 3: Try manual search in common locations (Homebrew, etc.)
+# Method 3: Try manual search in common locations (Homebrew, etc.) — macOS only
 if(NOT LIBWEBSOCKETS_LINKED AND APPLE)
-  # Check common Homebrew paths
   set(HOMEBREW_PREFIXES "/opt/homebrew" "/usr/local")
   foreach(prefix ${HOMEBREW_PREFIXES})
     if(EXISTS "${prefix}/include/libwebsockets.h")
@@ -138,8 +225,8 @@ endif()
 if(NOT LIBWEBSOCKETS_LINKED)
   message(WARNING "libwebsockets not found. Xbox Live RTA monitoring will be disabled.")
   message(WARNING "To enable RTA monitoring, install libwebsockets:")
-  message(WARNING "  macOS: brew install libwebsockets")
-  message(WARNING "  Linux: apt-get install libwebsockets-dev (or dnf install libwebsockets-devel)")
+  message(WARNING "  macOS:   brew install libwebsockets")
+  message(WARNING "  Linux:   apt-get install libwebsockets-dev (or dnf install libwebsockets-devel)")
   message(WARNING "  Windows: vcpkg install libwebsockets:x64-windows-static (or arm64-windows-static)")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,14 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE CURL::libcurl)
 
 # WebSocket client for Xbox Live RTA monitoring
 #
-# IMPORTANT (Linux): the plugin is a .so loaded at runtime by OBS.  OBS does
-# NOT bundle libwebsockets, so linking it dynamically produces a hard runtime
-# dependency on libwebsockets.so that the end-user must satisfy separately.
-# To avoid that, we always prefer the static archive (libwebsockets.a) on Linux.
+# Linux note: the plugin is a .so loaded at runtime by OBS.  OBS does NOT
+# bundle libwebsockets.so, so we must link libwebsockets statically to avoid a
+# hard runtime dependency.  The distro's libwebsockets-dev ships a .a that was
+# compiled WITHOUT -fPIC and therefore cannot be embedded in a shared object.
+# setup_ubuntu works around this by building libwebsockets from source with
+# -DCMAKE_POSITION_INDEPENDENT_CODE=ON and installing it to /usr/local, which
+# CMake searches before the system prefix.  The result is a PIC static archive
+# that links cleanly into achievements-tracker.so.
 #
 # LIBWEBSOCKETS_LINKED tracks whether we actually linked the library AND defined
 # HAVE_LIBWEBSOCKETS.  It is kept separate from the "package was found" flag so
@@ -75,36 +79,14 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE CURL::libcurl)
 # suppress the pkg-config fallback.
 set(LIBWEBSOCKETS_LINKED FALSE)
 
-# Helper: given a target, return the path to its static archive on Linux.
-# If the target already points to a .a, returns it directly.
-# Otherwise, looks for a libwebsockets.a beside the shared library.
-function(_lws_resolve_static_lib out_var imported_target)
-  set(_result "")
-  if(UNIX AND NOT APPLE)
-    get_target_property(_loc ${imported_target} IMPORTED_LOCATION)
-    if(NOT _loc)
-      get_target_property(_loc ${imported_target} LOCATION)
-    endif()
-    if(_loc MATCHES "\\.a$")
-      set(_result "${_loc}")
-    elseif(_loc)
-      # e.g. /usr/lib/x86_64-linux-gnu/libwebsockets.so  →  look for .a alongside
-      get_filename_component(_dir  "${_loc}" DIRECTORY)
-      get_filename_component(_name "${_loc}" NAME_WE)   # libwebsockets
-      if(EXISTS "${_dir}/${_name}.a")
-        set(_result "${_dir}/${_name}.a")
-      endif()
-    endif()
-  endif()
-  set(${out_var} "${_result}" PARENT_SCOPE)
-endfunction()
-
 # Method 1: Try CMake's find_package
+# On Linux this will pick up the LibwebsocketsConfig.cmake installed to
+# /usr/local by the from-source build in setup_ubuntu.
 find_package(Libwebsockets QUIET)
 if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
   # Probe all known target names produced by various libwebsockets CMake configs.
-  # Ubuntu's libwebsockets-dev creates Libwebsockets::websockets (namespaced),
-  # while vcpkg/source builds may create websockets or websockets_shared.
+  # The from-source / vcpkg builds create Libwebsockets::websockets (namespaced),
+  # older configs may use websockets or websockets_shared.
   set(_lws_target "")
   foreach(_candidate IN ITEMS
       Libwebsockets::websockets
@@ -117,20 +99,7 @@ if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
   endforeach()
 
   if(_lws_target)
-    if(UNIX AND NOT APPLE)
-      # On Linux prefer the static archive to avoid a runtime .so dependency.
-      _lws_resolve_static_lib(_lws_static_lib ${_lws_target})
-      if(_lws_static_lib)
-        message(STATUS "Found libwebsockets via CMake package — linking static archive: ${_lws_static_lib}")
-        target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE "${_lws_static_lib}")
-      else()
-        message(WARNING "libwebsockets static archive (.a) not found beside shared lib — falling back to dynamic link.")
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${_lws_target})
-      endif()
-    else()
-      target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${_lws_target})
-    endif()
+    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${_lws_target})
     # Static libwebsockets on Windows requires Winsock; link it explicitly since
     # the imported target does not always propagate it as a dependency.
     if(WIN32)
@@ -138,9 +107,7 @@ if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
     endif()
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
     set(LIBWEBSOCKETS_LINKED TRUE)
-    if(NOT (UNIX AND NOT APPLE))
-      message(STATUS "Found libwebsockets via CMake package (target: ${_lws_target})")
-    endif()
+    message(STATUS "Found libwebsockets via CMake package (target: ${_lws_target})")
   endif()
 endif()
 
@@ -148,58 +115,13 @@ endif()
 if(NOT LIBWEBSOCKETS_LINKED)
   find_package(PkgConfig QUIET)
   if(PkgConfig_FOUND)
-    if(UNIX AND NOT APPLE)
-      # Use STATIC so pkg_check_modules also returns transitive dependencies
-      # (libcap, libssl, …) that the static archive requires at link time.
-      pkg_check_modules(LIBWEBSOCKETS QUIET STATIC libwebsockets)
-      if(LIBWEBSOCKETS_FOUND)
-        # Try to locate the static archive (.a) from the library search dirs.
-        set(_lws_static_lib "")
-        foreach(_lws_lib_dir IN LISTS LIBWEBSOCKETS_LIBRARY_DIRS)
-          if(EXISTS "${_lws_lib_dir}/libwebsockets.a")
-            set(_lws_static_lib "${_lws_lib_dir}/libwebsockets.a")
-            break()
-          endif()
-        endforeach()
-        # Also search well-known system lib dirs if not found above.
-        if(NOT _lws_static_lib)
-          foreach(_sys_dir IN ITEMS
-              /usr/lib/x86_64-linux-gnu
-              /usr/lib/aarch64-linux-gnu
-              /usr/lib
-              /usr/local/lib)
-            if(EXISTS "${_sys_dir}/libwebsockets.a")
-              set(_lws_static_lib "${_sys_dir}/libwebsockets.a")
-              break()
-            endif()
-          endforeach()
-        endif()
-
-        target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
-        if(_lws_static_lib)
-          message(STATUS "Found libwebsockets via pkg-config — linking static archive: ${_lws_static_lib}")
-          # Link the .a directly, then the transitive static deps reported by
-          # pkg-config (libcap, libssl, etc.).  CMake deduplicates automatically.
-          target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
-            "${_lws_static_lib}"
-            ${LIBWEBSOCKETS_STATIC_LIBRARIES}
-          )
-        else()
-          message(WARNING "libwebsockets static archive (.a) not found — falling back to dynamic link.")
-          target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_LIBRARIES})
-        endif()
-        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
-        set(LIBWEBSOCKETS_LINKED TRUE)
-      endif()
-    else()
-      pkg_check_modules(LIBWEBSOCKETS QUIET libwebsockets)
-      if(LIBWEBSOCKETS_FOUND)
-        target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_LIBRARIES})
-        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
-        set(LIBWEBSOCKETS_LINKED TRUE)
-        message(STATUS "Found libwebsockets via pkg-config")
-      endif()
+    pkg_check_modules(LIBWEBSOCKETS QUIET libwebsockets)
+    if(LIBWEBSOCKETS_FOUND)
+      target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
+      target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_LIBRARIES})
+      target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
+      set(LIBWEBSOCKETS_LINKED TRUE)
+      message(STATUS "Found libwebsockets via pkg-config")
     endif()
   endif()
 endif()
@@ -226,7 +148,7 @@ if(NOT LIBWEBSOCKETS_LINKED)
   message(WARNING "libwebsockets not found. Xbox Live RTA monitoring will be disabled.")
   message(WARNING "To enable RTA monitoring, install libwebsockets:")
   message(WARNING "  macOS:   brew install libwebsockets")
-  message(WARNING "  Linux:   apt-get install libwebsockets-dev (or dnf install libwebsockets-devel)")
+  message(WARNING "  Linux:   built from source with -fPIC by setup_ubuntu (see .github/scripts/utils.zsh/setup_ubuntu)")
   message(WARNING "  Windows: vcpkg install libwebsockets:x64-windows-static (or arm64-windows-static)")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,32 +63,46 @@ find_package(CURL REQUIRED)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE CURL::libcurl)
 
 # WebSocket client for Xbox Live RTA monitoring
-# Try multiple methods to find libwebsockets
-set(LIBWEBSOCKETS_FOUND FALSE)
+# Try multiple methods to find libwebsockets.
+# LIBWEBSOCKETS_LINKED tracks whether we actually linked the library AND defined
+# HAVE_LIBWEBSOCKETS. LIBWEBSOCKETS_FOUND only records that the package was
+# located; the two are kept separate so that a successful find_package() that
+# doesn't produce a usable target doesn't suppress the pkg-config fallback.
+set(LIBWEBSOCKETS_LINKED FALSE)
 
 # Method 1: Try CMake's find_package
 find_package(Libwebsockets QUIET)
 if(Libwebsockets_FOUND OR LIBWEBSOCKETS_FOUND)
-  set(LIBWEBSOCKETS_FOUND TRUE)
-  if(TARGET websockets OR TARGET websockets_shared)
-    # Use the imported target
-    if(TARGET websockets_shared)
-      target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE websockets_shared)
-    else()
-      target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE websockets)
+  # Probe all known target names produced by various libwebsockets CMake configs.
+  # Ubuntu's libwebsockets-dev typically installs a config that creates
+  # Libwebsockets::websockets (namespaced), while vcpkg/source builds may
+  # create websockets or websockets_shared.
+  set(_lws_target "")
+  foreach(_candidate IN ITEMS
+      Libwebsockets::websockets
+      websockets_shared
+      websockets)
+    if(TARGET ${_candidate})
+      set(_lws_target ${_candidate})
+      break()
     endif()
+  endforeach()
+
+  if(_lws_target)
+    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${_lws_target})
     # Static libwebsockets on Windows requires Winsock; link it explicitly since
     # the imported target does not always propagate it as a dependency.
     if(WIN32)
       target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ws2_32 dbghelp)
     endif()
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
-    message(STATUS "Found libwebsockets via CMake package")
+    set(LIBWEBSOCKETS_LINKED TRUE)
+    message(STATUS "Found libwebsockets via CMake package (target: ${_lws_target})")
   endif()
 endif()
 
-# Method 2: Try pkg-config if CMake method didn't work
-if(NOT LIBWEBSOCKETS_FOUND)
+# Method 2: Try pkg-config when CMake method didn't produce a usable target
+if(NOT LIBWEBSOCKETS_LINKED)
   find_package(PkgConfig QUIET)
   if(PkgConfig_FOUND)
     pkg_check_modules(LIBWEBSOCKETS QUIET libwebsockets)
@@ -96,13 +110,14 @@ if(NOT LIBWEBSOCKETS_FOUND)
       target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
       target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${LIBWEBSOCKETS_LIBRARIES})
       target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
+      set(LIBWEBSOCKETS_LINKED TRUE)
       message(STATUS "Found libwebsockets via pkg-config")
     endif()
   endif()
 endif()
 
 # Method 3: Try manual search in common locations (Homebrew, etc.)
-if(NOT LIBWEBSOCKETS_FOUND AND APPLE)
+if(NOT LIBWEBSOCKETS_LINKED AND APPLE)
   # Check common Homebrew paths
   set(HOMEBREW_PREFIXES "/opt/homebrew" "/usr/local")
   foreach(prefix ${HOMEBREW_PREFIXES})
@@ -112,7 +127,7 @@ if(NOT LIBWEBSOCKETS_FOUND AND APPLE)
         target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE "${prefix}/lib")
         target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE websockets)
         target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_LIBWEBSOCKETS)
-        set(LIBWEBSOCKETS_FOUND TRUE)
+        set(LIBWEBSOCKETS_LINKED TRUE)
         message(STATUS "Found libwebsockets in ${prefix}")
         break()
       endif()
@@ -120,7 +135,7 @@ if(NOT LIBWEBSOCKETS_FOUND AND APPLE)
   endforeach()
 endif()
 
-if(NOT LIBWEBSOCKETS_FOUND)
+if(NOT LIBWEBSOCKETS_LINKED)
   message(WARNING "libwebsockets not found. Xbox Live RTA monitoring will be disabled.")
   message(WARNING "To enable RTA monitoring, install libwebsockets:")
   message(WARNING "  macOS: brew install libwebsockets")

--- a/buildspec.json
+++ b/buildspec.json
@@ -6,6 +6,7 @@
             "label": "OBS sources",
             "hashes": {
                 "macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
+                "ubuntu-x86_64": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
                 "windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf",
                 "windows-arm64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
             }

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -52,28 +52,58 @@ function(_setup_obs_studio)
     set(_is_fresh --fresh)
   endif()
 
+  set(_cmake_generator_args)
+  set(_cmake_arch_args)
+  set(_cmake_extra_args)
+
+  string(REPLACE ";" "\\;" _obs_prefix_path "${CMAKE_PREFIX_PATH}")
+
   if(OS_WINDOWS)
-    set(_cmake_generator "${CMAKE_GENERATOR}")
-    set(_cmake_arch "-A ${arch},version=${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
-    set(_cmake_extra "-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION} -DCMAKE_ENABLE_SCRIPTING=OFF")
+    set(_cmake_generator_args -G "${CMAKE_GENERATOR}")
+    set(_cmake_arch_args -A "${arch},version=${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+    list(APPEND _cmake_extra_args -DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION} -DCMAKE_ENABLE_SCRIPTING=OFF)
   elseif(OS_MACOS)
-    set(_cmake_generator "Xcode")
-    set(_cmake_arch "-DCMAKE_OSX_ARCHITECTURES:STRING='arm64;x86_64'")
-    set(_cmake_extra "-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    list(APPEND _cmake_extra_args -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+  elseif(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
+    set(_cmake_generator_args -G "${CMAKE_GENERATOR}")
+    list(
+      APPEND
+      _cmake_extra_args
+      -DCMAKE_BUILD_TYPE:STRING=Release
+      -DENABLE_UI:BOOL=OFF
+      -DENABLE_SCRIPTING:BOOL=OFF
+      -DENABLE_HEVC:BOOL=OFF
+      -DENABLE_PULSEAUDIO:BOOL=OFF
+      -DENABLE_WAYLAND:BOOL=OFF
+    )
   endif()
 
   message(STATUS "Configure ${label} (${arch})")
-  execute_process(
-    COMMAND
-      "${CMAKE_COMMAND}" -S "${dependencies_dir}/${_obs_destination}" -B
-      "${dependencies_dir}/${_obs_destination}/build_${arch}" -G ${_cmake_generator} "${_cmake_arch}"
-      -DOBS_CMAKE_VERSION:STRING=3.0.0 -DENABLE_PLUGINS:BOOL=OFF -DENABLE_FRONTEND:BOOL=OFF
-      -DOBS_VERSION_OVERRIDE:STRING=${_obs_version} "-DCMAKE_PREFIX_PATH='${CMAKE_PREFIX_PATH}'" ${_is_fresh}
-      ${_cmake_extra}
-    RESULT_VARIABLE _process_result
-    COMMAND_ERROR_IS_FATAL ANY
-    OUTPUT_QUIET
-  )
+  if(OS_MACOS)
+    execute_process(
+      COMMAND
+        "${CMAKE_COMMAND}" -S "${dependencies_dir}/${_obs_destination}" -B
+        "${dependencies_dir}/${_obs_destination}/build_${arch}" -G Xcode
+        "-DCMAKE_OSX_ARCHITECTURES:STRING='arm64;x86_64'" -DOBS_CMAKE_VERSION:STRING=3.0.0
+        -DENABLE_PLUGINS:BOOL=OFF -DENABLE_FRONTEND:BOOL=OFF -DOBS_VERSION_OVERRIDE:STRING=${_obs_version}
+        -DCMAKE_PREFIX_PATH=${_obs_prefix_path} ${_is_fresh} ${_cmake_extra_args}
+      RESULT_VARIABLE _process_result
+      COMMAND_ERROR_IS_FATAL ANY
+      OUTPUT_QUIET
+    )
+  else()
+    execute_process(
+      COMMAND
+        "${CMAKE_COMMAND}" -S "${dependencies_dir}/${_obs_destination}" -B
+        "${dependencies_dir}/${_obs_destination}/build_${arch}" ${_cmake_generator_args} ${_cmake_arch_args}
+        -DOBS_CMAKE_VERSION:STRING=3.0.0 -DENABLE_PLUGINS:BOOL=OFF -DENABLE_FRONTEND:BOOL=OFF
+        -DOBS_VERSION_OVERRIDE:STRING=${_obs_version} -DCMAKE_PREFIX_PATH=${_obs_prefix_path} ${_is_fresh}
+        ${_cmake_extra_args}
+      RESULT_VARIABLE _process_result
+      COMMAND_ERROR_IS_FATAL ANY
+      OUTPUT_QUIET
+    )
+  endif()
   message(STATUS "Configure ${label} (${arch}) - done")
 
   message(STATUS "Build ${label} (Debug - ${arch})")

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -84,9 +84,9 @@ function(_setup_obs_studio)
       COMMAND
         "${CMAKE_COMMAND}" -S "${dependencies_dir}/${_obs_destination}" -B
         "${dependencies_dir}/${_obs_destination}/build_${arch}" -G Xcode
-        "-DCMAKE_OSX_ARCHITECTURES:STRING='arm64;x86_64'" -DOBS_CMAKE_VERSION:STRING=3.0.0
-        -DENABLE_PLUGINS:BOOL=OFF -DENABLE_FRONTEND:BOOL=OFF -DOBS_VERSION_OVERRIDE:STRING=${_obs_version}
-        -DCMAKE_PREFIX_PATH=${_obs_prefix_path} ${_is_fresh} ${_cmake_extra_args}
+        "-DCMAKE_OSX_ARCHITECTURES:STRING='arm64;x86_64'" -DOBS_CMAKE_VERSION:STRING=3.0.0 -DENABLE_PLUGINS:BOOL=OFF
+        -DENABLE_FRONTEND:BOOL=OFF -DOBS_VERSION_OVERRIDE:STRING=${_obs_version} -DCMAKE_PREFIX_PATH=${_obs_prefix_path}
+        ${_is_fresh} ${_cmake_extra_args}
       RESULT_VARIABLE _process_result
       COMMAND_ERROR_IS_FATAL ANY
       OUTPUT_QUIET

--- a/cmake/linux/buildspec.cmake
+++ b/cmake/linux/buildspec.cmake
@@ -18,4 +18,3 @@ function(_check_dependencies_linux)
 endfunction()
 
 _check_dependencies_linux()
-

--- a/cmake/linux/buildspec.cmake
+++ b/cmake/linux/buildspec.cmake
@@ -1,0 +1,21 @@
+# CMake Linux build dependencies module
+
+include_guard(GLOBAL)
+
+include(buildspec_common)
+
+# _check_dependencies_linux: Set up Linux slice for _check_dependencies
+function(_check_dependencies_linux)
+  set(arch ${CMAKE_SYSTEM_PROCESSOR})
+  set(platform ubuntu-${arch})
+
+  set(dependencies_dir "${CMAKE_CURRENT_SOURCE_DIR}/.deps")
+  set(obs-studio_filename "VERSION.tar.gz")
+  set(obs-studio_destination "obs-studio-VERSION")
+  set(dependencies_list obs-studio)
+
+  _check_dependencies()
+endfunction()
+
+_check_dependencies_linux()
+

--- a/cmake/linux/defaults.cmake
+++ b/cmake/linux/defaults.cmake
@@ -7,9 +7,31 @@ include(GNUInstallDirs)
 
 include(buildspec)
 
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/buildspec.json" _linux_buildspec)
+string(JSON _obs_studio_version GET ${_linux_buildspec} dependencies obs-studio version)
+string(REGEX MATCH "^[0-9]+" _obs_studio_major "${_obs_studio_version}")
+math(EXPR _obs_studio_next_major "${_obs_studio_major} + 1")
+
+set(
+  CPACK_DEBIAN_PACKAGE_DEPENDS
+  "obs-studio (>= ${_obs_studio_version})"
+  "obs-studio (<< ${_obs_studio_next_major}~)"
+)
+
 if(CMAKE_INSTALL_LIBDIR MATCHES "(CMAKE_SYSTEM_PROCESSOR)")
   string(REPLACE "CMAKE_SYSTEM_PROCESSOR" "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
 endif()
+
+set(
+  CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS
+  "${CMAKE_CURRENT_SOURCE_DIR}/.deps/lib"
+  "${CMAKE_CURRENT_SOURCE_DIR}/.deps/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/.deps/lib/${CMAKE_C_LIBRARY_ARCHITECTURE}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/.deps/${CMAKE_INSTALL_LIBDIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/.deps/obs-studio-${_obs_studio_version}/build_${CMAKE_SYSTEM_PROCESSOR}/libobs"
+  "${CMAKE_CURRENT_SOURCE_DIR}/.deps/obs-studio-${_obs_studio_version}/build_${CMAKE_SYSTEM_PROCESSOR}/frontend/api"
+)
+
 
 # Enable find_package targets to become globally available targets
 set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL TRUE)

--- a/cmake/linux/defaults.cmake
+++ b/cmake/linux/defaults.cmake
@@ -5,6 +5,8 @@ include_guard(GLOBAL)
 # Set default installation directories
 include(GNUInstallDirs)
 
+include(buildspec)
+
 if(CMAKE_INSTALL_LIBDIR MATCHES "(CMAKE_SYSTEM_PROCESSOR)")
   string(REPLACE "CMAKE_SYSTEM_PROCESSOR" "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
 endif()

--- a/cmake/linux/defaults.cmake
+++ b/cmake/linux/defaults.cmake
@@ -12,11 +12,7 @@ string(JSON _obs_studio_version GET ${_linux_buildspec} dependencies obs-studio 
 string(REGEX MATCH "^[0-9]+" _obs_studio_major "${_obs_studio_version}")
 math(EXPR _obs_studio_next_major "${_obs_studio_major} + 1")
 
-set(
-  CPACK_DEBIAN_PACKAGE_DEPENDS
-  "obs-studio (>= ${_obs_studio_version})"
-  "obs-studio (<< ${_obs_studio_next_major}~)"
-)
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "obs-studio (>= ${_obs_studio_version})" "obs-studio (<< ${_obs_studio_next_major}~)")
 
 if(CMAKE_INSTALL_LIBDIR MATCHES "(CMAKE_SYSTEM_PROCESSOR)")
   string(REPLACE "CMAKE_SYSTEM_PROCESSOR" "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
@@ -31,7 +27,6 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/.deps/obs-studio-${_obs_studio_version}/build_${CMAKE_SYSTEM_PROCESSOR}/libobs"
   "${CMAKE_CURRENT_SOURCE_DIR}/.deps/obs-studio-${_obs_studio_version}/build_${CMAKE_SYSTEM_PROCESSOR}/frontend/api"
 )
-
 
 # Enable find_package targets to become globally available targets
 set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL TRUE)

--- a/cmake/windows/installer.nsi.in
+++ b/cmake/windows/installer.nsi.in
@@ -35,6 +35,12 @@ SetCompressorDictSize 32
   !define MUI_UNICON "@CMAKE_CURRENT_SOURCE_DIR@/cmake/windows/resources/installer.ico"
 !endif
 
+; Pre-populate the directory page with the detected OBS install path
+!define MUI_PAGE_CUSTOMFUNCTION_PRE PageDirectoryPre
+!define MUI_DIRECTORYPAGE_TEXT_TOP \
+    "The installer will place the plugin inside your OBS Studio installation folder.$\r$\n$\r$\nIf the path below is not correct, click Browse and navigate to your OBS Studio installation directory."
+!define MUI_DIRECTORYPAGE_TEXT_DESTINATION "OBS Studio Installation Folder"
+
 !insertmacro MUI_PAGE_WELCOME
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
@@ -63,31 +69,38 @@ Function FindOBSDir
     Push $0
 FunctionEnd
 
+; Pre-populate $INSTDIR with the detected OBS path before the directory page
+Function PageDirectoryPre
+    Call FindOBSDir
+    Pop $0
+    StrCpy $INSTDIR $0
+FunctionEnd
+
 ; ---------------------------------------------------------------------------
 ; Install section
 ; ---------------------------------------------------------------------------
 Section "Achievements Tracker Plugin" SecPlugin
 
-    Call FindOBSDir
-    Pop $R0  ; $R0 = OBS install directory
+    ; $INSTDIR is the OBS installation directory chosen by the user
+    ; (pre-populated from registry / default fallback by PageDirectoryPre)
 
     ; --- Plugin DLL ---
-    SetOutPath "$R0\obs-plugins\${PLUGIN_BIN_SUBDIR}"
+    SetOutPath "$INSTDIR\obs-plugins\${PLUGIN_BIN_SUBDIR}"
     File "@INSTALL_STAGE_DIR@\@CMAKE_PROJECT_NAME@\bin\${PLUGIN_BIN_SUBDIR}\${PLUGIN_DLL}"
 
     ; --- Plugin data (locale, effects, etc.) ---
-    SetOutPath "$R0\data\obs-plugins\${PLUGIN_NAME}"
+    SetOutPath "$INSTDIR\data\obs-plugins\${PLUGIN_NAME}"
     File /r "@INSTALL_STAGE_DIR@\@CMAKE_PROJECT_NAME@\data\"
 
     ; --- Write uninstaller ---
-    WriteUninstaller "$R0\obs-plugins\${PLUGIN_BIN_SUBDIR}\Uninstall-${PLUGIN_NAME}.exe"
+    WriteUninstaller "$INSTDIR\obs-plugins\${PLUGIN_BIN_SUBDIR}\Uninstall-${PLUGIN_NAME}.exe"
 
     ; --- Register in Add/Remove Programs ---
     WriteRegStr   HKLM "${UNINSTALL_KEY}" "DisplayName"          "${PLUGIN_DISPLAY} (${PLUGIN_ARCH})"
     WriteRegStr   HKLM "${UNINSTALL_KEY}" "DisplayVersion"       "${PLUGIN_VERSION}"
     WriteRegStr   HKLM "${UNINSTALL_KEY}" "Publisher"            "${PLUGIN_AUTHOR}"
-    WriteRegStr   HKLM "${UNINSTALL_KEY}" "InstallLocation"      "$R0"
-    WriteRegStr   HKLM "${UNINSTALL_KEY}" "UninstallString"      "$R0\obs-plugins\${PLUGIN_BIN_SUBDIR}\Uninstall-${PLUGIN_NAME}.exe"
+    WriteRegStr   HKLM "${UNINSTALL_KEY}" "InstallLocation"      "$INSTDIR"
+    WriteRegStr   HKLM "${UNINSTALL_KEY}" "UninstallString"      "$INSTDIR\obs-plugins\${PLUGIN_BIN_SUBDIR}\Uninstall-${PLUGIN_NAME}.exe"
     WriteRegDWORD HKLM "${UNINSTALL_KEY}" "NoModify"             1
     WriteRegDWORD HKLM "${UNINSTALL_KEY}" "NoRepair"             1
 


### PR DESCRIPTION
This pull request introduces several improvements to the build and packaging process, mainly focused on Linux/Ubuntu support, dependency management, and packaging output formats. The most significant changes include building `libwebsockets` from source with proper flags for static linking, updating the CMake logic for more robust library detection, enhancing the Ubuntu setup scripts, and ensuring both `.zip` and `.tar.xz` portable archives are produced and uploaded. These changes improve compatibility, portability, and ease of installation for users and CI consumers.

**Build and Dependency Management Improvements:**

* The Ubuntu setup script now builds `libwebsockets` from source with `-fPIC` to allow static linking into plugin `.so` files, resolving issues with the system package's static library and ensuring compatibility when embedded in shared objects. Additional build dependencies were added, and the script was restructured for clarity.
* The CMake logic for finding and linking `libwebsockets` was overhauled: it now prefers a static, position-independent build from `/usr/local`, tries multiple CMake target names, and falls back to `pkg-config` or manual paths as needed. This ensures robust detection and linking across platforms, with improved messaging and error handling.

**Linux Packaging and CMake Enhancements:**

* Added new CMake modules (`cmake/linux/buildspec.cmake`, `cmake/linux/defaults.cmake`) to improve Linux dependency checking and set up correct Debian package dependencies, including version pinning for `obs-studio` and private shlib directories for packaging.
* Updated the OBS Studio build process to handle platform-specific CMake arguments more cleanly, improving maintainability and correctness for Linux and macOS builds.

**Packaging Output and CI Workflow Updates:**

* The packaging script now always produces a portable `.zip` archive (in addition to `.tar.xz` for backwards compatibility), making manual installation easier for users without a package manager.
* CI workflows were updated to upload both `.zip` and `.tar.xz` artifacts, and to expect `.zip` files for Ubuntu builds, improving artifact accessibility and consistency.

**Windows Installer Usability:**

* The Windows NSIS installer now pre-populates the install directory with the detected OBS Studio path, improving user experience and reducing installation errors.

**Buildspec and Versioning:**

* The `buildspec.json` was updated to include the correct hash for Ubuntu OBS sources, ensuring version consistency.