### PR TITLE
Remove unused branch filters in push workflow and fix memory dealloca…

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,10 +2,6 @@ name: Push
 run-name: ${{ github.ref_name }} push run 🚀
 on:
   push:
-    branches:
-      - master
-      - main
-      - 'release/**'
     tags:
       - '*'
 permissions:

--- a/src/common/device.c
+++ b/src/common/device.c
@@ -14,5 +14,5 @@ void free_device(device_t **device) {
         EVP_PKEY_free((*device)->keys);
     }
 
-    free_memory((void **)&device);
+    free_memory((void **)device);
 }


### PR DESCRIPTION
This pull request contains a minor fix to memory management in the `free_device` function and a change to the GitHub Actions workflow trigger configuration.

Workflow configuration:

* Updated `.github/workflows/push.yaml` to remove explicit branch filters under the `push` event, so the workflow will now trigger on all branch pushes and tags, not just specific branches.

Memory management:

* Fixed the call to `free_memory` in `src/common/device.c` by passing the correct pointer type, ensuring proper deallocation of the `device_t` pointer.