### PR TITLE
Fix installer to correctly locate OBS Studio registry entry on 64-bit…

### DIFF
--- a/cmake/windows/installer.nsi.in
+++ b/cmake/windows/installer.nsi.in
@@ -55,17 +55,19 @@ SetCompressorDictSize 32
 ; Helpers
 ; ---------------------------------------------------------------------------
 
-; Locate OBS Studio install dir from registry (64-bit first, then 32-bit view)
+; Locate OBS Studio install dir from registry.
+; SetRegView 64 is required because makensis produces a 32-bit executable and
+; WOW64 would otherwise silently redirect HKLM\SOFTWARE reads to
+; HKLM\SOFTWARE\WOW6432Node, where OBS Studio (a 64-bit app) does not write.
 Function FindOBSDir
+    SetRegView 64
     ClearErrors
     ReadRegStr $0 HKLM "SOFTWARE\OBS Studio" ""
     ${If} ${Errors}
-        ReadRegStr $0 HKLM "SOFTWARE\WOW6432Node\OBS Studio" ""
-    ${EndIf}
-    ${If} ${Errors}
-        ; Fall back to default Program Files location
+        ; Fall back to default 64-bit Program Files location
         StrCpy $0 "$PROGRAMFILES64\obs-studio"
     ${EndIf}
+    SetRegView lastused
     Push $0
 FunctionEnd
 


### PR DESCRIPTION
This pull request improves the reliability of locating the OBS Studio installation directory during the Windows installer process. The main change ensures that registry lookups correctly target the 64-bit registry view, which is necessary because OBS Studio is a 64-bit application and its registry keys are not present in the 32-bit view.

Installer registry lookup improvements:

* Modified the `FindOBSDir` function in `installer.nsi.in` to explicitly use the 64-bit registry view (`SetRegView 64`) when searching for the OBS Studio install directory, preventing incorrect redirection to the 32-bit registry node. The fallback to the 32-bit view and its associated logic were removed, and the function now restores the previous registry view at the end.