### PR TITLE
[PL-78] - Fix issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,7 @@ target_sources(
     src/integrations/monitoring_service.c
     src/integrations/retro-achievements/retro_achievements_monitor.c
     src/ui/xbox_account_config.cpp
+    src/ui/achievement_tracker_config.cpp
     src/io/state.c
     src/io/cache.c
     src/encoding/base64.c

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A cross-platform OBS Studio plugin that displays Xbox Live and RetroAchievements
 - **Unified monitoring service** that handles both Xbox and RetroAchievements sessions with last-game-received priority
 - **Profile sources** for gamertag, gamerpic, and gamerscore
 - **Achievement sources** for name, description, icon, and progress count
+- **Automatic achievement cycle** that rotates through the last unlocked achievement and random locked achievements on a configurable timer
+- **Manual navigation hotkeys** (default: Shift+← / Shift+→) to step through achievements on demand
 - **Customizable text sources** with persisted font and gradient color settings
 - **Cross-platform builds** for Windows, macOS, and Linux
 
@@ -56,6 +58,8 @@ After installation, restart OBS Studio.
 
 ### Configuration
 
+#### Xbox account sign-in
+
 1. Open OBS Studio.
 2. Open **Tools** → **Xbox Account**.
 3. Use the global Xbox Account dialog to review the current status and click **Sign in with Xbox**.
@@ -66,6 +70,17 @@ After installation, restart OBS Studio.
 All Xbox sources in the plugin share the same authenticated account. RetroAchievements sources connect automatically when a RetroArch WebSocket server is detected on the local machine.
 
 ![Xbox Account dialog](images/plugin-xbox-account.png)
+
+#### Achievement Tracker hotkeys
+
+Open **Tools** → **Achievement Tracker** to see the currently configured navigation shortcuts.
+
+| Action | Default shortcut |
+| --- | --- |
+| Previous Achievement | Shift + ← |
+| Next Achievement | Shift + → |
+
+To change these shortcuts, open **OBS Settings** → **Hotkeys** and search for _Achievement Tracker_. The defaults are applied automatically the first time the plugin loads; after that OBS persists any changes you make.
 
 ### Available OBS Sources
 
@@ -87,6 +102,30 @@ Account sign-in and sign-out are managed globally from **Tools** → **Xbox Acco
 - **Achievement (Description)**: current achievement description
 - **Achievement (Icon)**: current achievement icon
 - **Achievements’ Count**: unlocked / total achievements for the current game (for example `12 / 50`)
+
+#### Achievement display cycle
+
+The four achievement sources above all stay in sync via a shared display cycle. Once the game session is fully ready (all achievement icons cached locally), the cycle runs automatically:
+
+| Phase | Default duration | What is shown |
+| --- | --- | --- |
+| Last unlocked | 45 s | The most recently unlocked achievement. If no achievement has been unlocked yet, a random locked achievement is shown instead. |
+| Locked rotation | 120 s total (30 s each) | Random locked achievements, cycling every 30 seconds. |
+
+After the locked rotation phase ends the cycle returns to the last-unlocked phase and repeats.
+
+All three durations are configurable. Open **Tools** → **Achievement Tracker**, adjust the values in the **Display Timing** section, and click **Save**. Changes take effect immediately and are persisted across OBS restarts.
+
+Constraints enforced by the UI and the cycle engine:
+- Minimum value for any duration: **5 seconds**.
+- **Locked rotation total** must be ≥ **Each locked** — guaranteeing at least one locked achievement is shown per rotation pass.
+
+**Manual navigation** lets you step through the full achievement list at any time without waiting for the timer:
+
+- **Shift + ←** — previous achievement
+- **Shift + →** — next achievement
+
+Pressing either key immediately displays the adjacent achievement in the sorted list (unlocked achievements first, ordered by unlock time; locked achievements follow) and resets the phase timer so the selected achievement stays visible for the full interval before the automatic cycle resumes.
 
 #### Real-time updates
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A cross-platform OBS Studio plugin that displays Xbox Live and RetroAchievements
 
 - **Global Xbox account configuration dialog** using Microsoft's device-code flow
 - **Real-time game and achievement tracking** through Xbox Live RTA monitoring when available
-- **RetroAchievements integration** via a local RetroArch WebSocket server for retro game tracking
+- **RetroAchievements integration** via a local RetroArch WebSocket server for retro game tracking — requires the [Octelys custom build of RetroArch](https://github.com/Octelys/retro-arch/releases/latest)
 - **Unified monitoring service** that handles both Xbox and RetroAchievements sessions with last-game-received priority
 - **Profile sources** for gamertag, gamerpic, and gamerscore
 - **Achievement sources** for name, description, icon, and progress count
@@ -69,6 +69,14 @@ After installation, restart OBS Studio.
 
 All Xbox sources in the plugin share the same authenticated account. RetroAchievements sources connect automatically when a RetroArch WebSocket server is detected on the local machine.
 
+> **⚠️ RetroAchievements requires a custom build of RetroArch**
+>
+> The standard RetroArch release does not include the WebSocket game-state server used by this plugin. You must install the **Octelys custom build of RetroArch**, which adds that server.
+>
+> Download the latest release: [github.com/Octelys/retro-arch/releases/latest](https://github.com/Octelys/retro-arch/releases/latest) (currently **RetroArch 1.22.2.37**)
+>
+> Available for **Windows (x64)**, **macOS**, and **Linux (x86_64)**.
+
 ![Xbox Account dialog](images/plugin-xbox-account.png)
 
 #### Achievement Tracker hotkeys
@@ -79,6 +87,9 @@ Open **Tools** → **Achievement Tracker** to see the currently configured navig
 | --- | --- |
 | Previous Achievement | Shift + ← |
 | Next Achievement | Shift + → |
+| First Unlocked Achievement | Shift + ↑ |
+| First Locked Achievement | Shift + ↓ |
+| Toggle Auto Cycle | Shift + Space |
 
 To change these shortcuts, open **OBS Settings** → **Hotkeys** and search for _Achievement Tracker_. The defaults are applied automatically the first time the plugin loads; after that OBS persists any changes you make.
 
@@ -124,8 +135,11 @@ Constraints enforced by the UI and the cycle engine:
 
 - **Shift + ←** — previous achievement
 - **Shift + →** — next achievement
+- **Shift + ↑** — jump to the first (most recently) unlocked achievement
+- **Shift + ↓** — jump to the first locked achievement
+- **Shift + Space** — toggle the automatic cycle on/off
 
-Pressing either key immediately displays the adjacent achievement in the sorted list (unlocked achievements first, ordered by unlock time; locked achievements follow) and resets the phase timer so the selected achievement stays visible for the full interval before the automatic cycle resumes.
+Pressing ← / → immediately displays the adjacent achievement in the sorted list (unlocked achievements first, ordered by unlock time; locked achievements follow) and resets the phase timer so the selected achievement stays visible for the full interval before the automatic cycle resumes.
 
 #### Real-time updates
 
@@ -139,6 +153,8 @@ When a local RetroArch WebSocket server is detected, the plugin additionally tra
 - current retro game changes
 - achievement list and unlock updates
 - user identity (display name, score, avatar)
+
+> This requires the [Octelys custom build of RetroArch](https://github.com/Octelys/retro-arch/releases/latest), which includes the WebSocket game-state server not present in the standard RetroArch release.
 
 The active identity shown in profile sources is determined by whichever integration last reported a game change. If only one integration has an active game, that integration's identity is used.
 

--- a/src/common/achievement.c
+++ b/src/common/achievement.c
@@ -26,6 +26,7 @@ achievement_t *copy_achievement(const achievement_t *achievement) {
         copy->name               = bstrdup(current->name);
         copy->description        = bstrdup(current->description);
         copy->icon_url           = bstrdup(current->icon_url);
+        copy->measured_progress  = bstrdup(current->measured_progress);
         copy->is_secret          = current->is_secret;
         copy->value              = current->value;
         copy->unlocked_timestamp = current->unlocked_timestamp;
@@ -61,6 +62,7 @@ void free_achievement(achievement_t **achievement) {
         free_memory((void **)&current->name);
         free_memory((void **)&current->description);
         free_memory((void **)&current->icon_url);
+        free_memory((void **)&current->measured_progress);
         free_memory((void **)&current);
 
         current = next;

--- a/src/common/achievement.h
+++ b/src/common/achievement.h
@@ -58,6 +58,12 @@ typedef struct achievement {
     char                *icon_url;
     /** Unix timestamp (seconds since epoch) when unlocked; 0 if still locked. */
     int64_t              unlocked_timestamp;
+    /**
+     * Progress string for measured achievements (e.g. "5/10").
+     *
+     * NULL when not applicable (Xbox achievements or non-measured retro ones).
+     */
+    char                *measured_progress;
     /** Which integration produced this achievement. */
     achievement_source_t source;
     /** Next achievement in the list, or NULL. */

--- a/src/common/memory.h
+++ b/src/common/memory.h
@@ -57,7 +57,7 @@ static void free_json_memory(void **ptr) {
         return;
     }
 
-    cJSON_Delete(*ptr);
+    cJSON_Delete((cJSON *)*ptr);
     *ptr = NULL;
 }
 

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -201,6 +201,31 @@ typedef struct achievements_count_configuration {
     uint32_t    bottom_color;
 } achievements_count_configuration_t;
 
+/** Minimum allowed value (seconds) for any achievement cycle duration setting. */
+#define ACHIEVEMENT_CYCLE_MIN_DURATION 5
+
+/** Default seconds to display the last-unlocked achievement. */
+#define ACHIEVEMENT_CYCLE_DEFAULT_LAST_UNLOCKED_DURATION   45
+
+/** Default seconds to display each random locked achievement. */
+#define ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_EACH_DURATION     30
+
+/** Default total seconds to spend in the locked-rotation phase. */
+#define ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_TOTAL_DURATION   120
+
+/**
+ * @brief Configurable display-duration settings for the achievement cycle.
+ */
+typedef struct achievement_cycle_timings {
+    /** Seconds to display the last-unlocked achievement. Default: ACHIEVEMENT_CYCLE_DEFAULT_LAST_UNLOCKED_DURATION. */
+    int last_unlocked_duration;
+    /** Seconds to display each random locked achievement. Default: ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_EACH_DURATION. */
+    int locked_achievement_duration;
+    /** Total seconds to spend in the locked-rotation phase. Default: ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_TOTAL_DURATION.
+     */
+    int locked_cycle_total_duration;
+} achievement_cycle_timings_t;
+
 /**
  * @brief Dummy type to ensure OpenSSL public types are available to consumers.
  *

--- a/src/integrations/monitoring_service.c
+++ b/src/integrations/monitoring_service.c
@@ -312,10 +312,17 @@ static void on_xbox_game_played(const game_t *game) {
     g_xbox_game = copy_game(game);
 
     if (!g_xbox_game) {
-        /* Game stopped — clear achievements immediately since on_xbox_session_ready
-         * will not fire for a NULL game. */
-        replace_current_achievements(NULL);
+        /* Xbox game stopped. If a retro game is still active, do not disturb
+         * its session: keep the retro achievements in place and let the cycle
+         * keep running. Only re-evaluate the active identity so the gamertag /
+         * gamerpic switch to the retro identity if needed. */
+        if (g_retro_game) {
+            notify_active_identity(get_current_active_identity());
+            return;
+        }
 
+        /* No active game on either source — clear everything. */
+        replace_current_achievements(NULL);
         notify_active_identity(get_current_active_identity());
         notify_game_played(NULL);
         return;
@@ -348,9 +355,15 @@ static void on_xbox_game_played(const game_t *game) {
  * @brief Xbox monitor callback invoked when the session is fully ready.
  *
  * Converts the Xbox achievements to generic form and caches them, then
- * notifies subscribers.
+ * notifies subscribers. Skipped when Xbox has no active game (e.g. the Xbox
+ * monitor fires a session-ready after reporting "game stopped") to avoid
+ * overwriting data from another source such as RetroAchievements.
  */
 static void on_xbox_session_ready(void) {
+    if (!g_xbox_game) {
+        return;
+    }
+
     replace_current_achievements(xbox_to_achievements(get_current_game_achievements()));
 
     notify_session_ready();

--- a/src/integrations/monitoring_service.c
+++ b/src/integrations/monitoring_service.c
@@ -204,12 +204,12 @@ static achievement_t *retro_to_achievements(const retro_achievement_t *retro, si
         snprintf(id_buf, sizeof(id_buf), "%u", r->id);
         a->id = bstrdup(id_buf);
 
-        a->name               = bstrdup(r->name);
-        a->description        = bstrdup(r->description);
-        a->icon_url           = bstrdup(r->badge_url);
-        a->measured_progress  = (r->measured_progress[0] != '\0') ? bstrdup(r->measured_progress) : NULL;
-        a->is_secret          = false;
-        a->value              = (int)r->points;
+        a->name              = bstrdup(r->name);
+        a->description       = bstrdup(r->description);
+        a->icon_url          = bstrdup(r->badge_url);
+        a->measured_progress = (r->measured_progress[0] != '\0') ? bstrdup(r->measured_progress) : NULL;
+        a->is_secret         = false;
+        a->value             = (int)r->points;
         /* Use the real unlock timestamp when available; fall back to 1 (a
          * non-zero sentinel meaning "unlocked at unknown time") when the
          * server reports status="unlocked" but omits unlock_time. */
@@ -220,7 +220,7 @@ static achievement_t *retro_to_achievements(const retro_achievement_t *retro, si
         } else {
             a->unlocked_timestamp = 0;
         }
-        a->source             = ACHIEVEMENT_SOURCE_RETRO;
+        a->source = ACHIEVEMENT_SOURCE_RETRO;
 
         if (previous) {
             previous->next = a;

--- a/src/integrations/monitoring_service.c
+++ b/src/integrations/monitoring_service.c
@@ -207,9 +207,19 @@ static achievement_t *retro_to_achievements(const retro_achievement_t *retro, si
         a->name               = bstrdup(r->name);
         a->description        = bstrdup(r->description);
         a->icon_url           = bstrdup(r->badge_url);
+        a->measured_progress  = (r->measured_progress[0] != '\0') ? bstrdup(r->measured_progress) : NULL;
         a->is_secret          = false;
         a->value              = (int)r->points;
-        a->unlocked_timestamp = (strcmp(r->status, "unlocked") == 0) ? 1 : 0;
+        /* Use the real unlock timestamp when available; fall back to 1 (a
+         * non-zero sentinel meaning "unlocked at unknown time") when the
+         * server reports status="unlocked" but omits unlock_time. */
+        if (r->unlock_time > 0) {
+            a->unlocked_timestamp = (int64_t)r->unlock_time;
+        } else if (strcmp(r->status, "unlocked") == 0) {
+            a->unlocked_timestamp = 1;
+        } else {
+            a->unlocked_timestamp = 0;
+        }
         a->source             = ACHIEVEMENT_SOURCE_RETRO;
 
         if (previous) {
@@ -351,8 +361,27 @@ static void on_xbox_session_ready(void) {
  * ----------------------------------------------------------------------- */
 
 static void on_retro_connection_changed(bool connected, const char *error_message) {
-    if (!connected)
+    if (!connected) {
+        /* Treat a disconnect the same as no_game + no_user so that all
+         * subscribers (game cover, achievement sources, identity sources)
+         * are cleared immediately instead of staying stale. */
         free_identity_t(&g_retro_identity);
+
+        if (g_retro_game) {
+            free_game(&g_retro_game);
+
+            /* Fire game_played(NULL) BEFORE clearing achievements so that the
+             * achievement cycle sets g_session_ready = false first, preventing
+             * reset_display_cycle() from running with an empty list. */
+            notify_game_played(NULL);
+            notify_active_identity(get_current_active_identity());
+            replace_current_achievements(NULL);
+        } else {
+            /* No game was active, but still re-evaluate the active identity
+             * in case the retro identity was the one being shown. */
+            notify_active_identity(get_current_active_identity());
+        }
+    }
 
     if (g_connection_changed_callback)
         g_connection_changed_callback(connected, error_message);
@@ -395,33 +424,51 @@ static void on_retro_game_playing(const retro_game_t *retro_game) {
 
     g_last_game_source = IDENTITY_SOURCE_RETRO;
 
-    /* Clear cached achievements — they belong to the previous game. */
-    replace_current_achievements(NULL);
-
-    /* Retro is now the last game source. get_current_active_identity() will
-     * return the retro identity if it is cached, or NULL if the user message
-     * has not arrived yet (it will re-notify via on_retro_user). */
+    /* Notify game_played BEFORE clearing achievements so that the achievement
+     * cycle can mark the session as not-ready before on_achievements_changed
+     * fires. If we cleared achievements first while g_session_ready was still
+     * true, reset_display_cycle() would run with an empty list and notify all
+     * subscribers with NULL, causing the name/description sources to blank out
+     * permanently until the new session becomes ready. */
     notify_active_identity(get_current_active_identity());
-
     notify_game_played(g_retro_game);
+
+    /* Clear cached achievements — they belong to the previous game.
+     * Done after notify_game_played so achievement_cycle has already set
+     * g_session_ready = false, making the resulting on_achievements_changed
+     * call a no-op inside reset_display_cycle(). */
+    replace_current_achievements(NULL);
 }
 
 static void on_retro_no_game(void) {
     free_game(&g_retro_game);
-    /* Clear achievements and notify all subscribers: no game is active and
-     * therefore no identity is active either. */
-    replace_current_achievements(NULL);
+
+    /* Notify game_played BEFORE clearing achievements so that the achievement
+     * cycle sets g_session_ready = false first.  Otherwise replace_current_achievements(NULL)
+     * would fire on_achievements_changed → reset_display_cycle() while
+     * g_session_ready is still true, blanking out the sources. */
     notify_game_played(NULL);
     notify_active_identity(get_current_active_identity());
+
+    /* Clear achievements now that the cycle is no longer active. */
+    replace_current_achievements(NULL);
 }
 
 /**
  * @brief RetroAchievements callback invoked when the achievements' list is received.
+ *
+ * Only fires notify_session_ready() when a game is actually active.
+ * RetroArch may send an achievements message with count=0 after a no_game
+ * event (initial state dump on connection). Treating that as session-ready
+ * would set g_session_ready = true with no game context, which could then
+ * block the next real game's session from starting correctly.
  */
 static void on_retro_achievements(const retro_achievement_t *achievements, size_t count) {
     replace_current_achievements(retro_to_achievements(achievements, count));
 
-    notify_session_ready();
+    if (g_retro_game) {
+        notify_session_ready();
+    }
 }
 
 /* --------------------------------------------------------------------------

--- a/src/integrations/retro-achievements/retro_achievements_monitor.c
+++ b/src/integrations/retro-achievements/retro_achievements_monitor.c
@@ -332,6 +332,14 @@ static void on_message_received(const char *buffer) {
             if (json_item_is_string(field))
                 strncpy(ach->status, field->valuestring, sizeof(ach->status) - 1);
 
+            field = cJSON_GetObjectItemCaseSensitive(item, "unlock_time");
+            if (field != NULL && (field->type & cJSON_Number))
+                ach->unlock_time = (uint64_t)field->valuedouble;
+
+            field = cJSON_GetObjectItemCaseSensitive(item, "measured_progress");
+            if (json_item_is_string(field))
+                strncpy(ach->measured_progress, field->valuestring, sizeof(ach->measured_progress) - 1);
+
             field = cJSON_GetObjectItemCaseSensitive(item, "badge_url");
             if (json_item_is_string(field))
                 strncpy(ach->badge_url, field->valuestring, sizeof(ach->badge_url) - 1);

--- a/src/integrations/retro-achievements/retro_achievements_monitor.h
+++ b/src/integrations/retro-achievements/retro_achievements_monitor.h
@@ -79,15 +79,15 @@ typedef struct {
  *        server inside an @c "achievements" message.
  */
 typedef struct {
-    uint32_t id;                       /**< Numeric achievement ID.                                  */
-    char     name[256];                /**< Achievement title.                                       */
-    char     description[1024];        /**< Achievement description.                                 */
-    uint32_t points;                   /**< Point value of the achievement.                          */
-    char     status[16];               /**< "unlocked" or "locked".                                  */
-    uint64_t unlock_time;              /**< Unix timestamp (seconds) when unlocked; 0 if locked.     */
-    char     measured_progress[64];    /**< Progress string for measured achievements (e.g. "5/10");
-                                            empty when not applicable.                               */
-    char     badge_url[512];           /**< Unlocked badge image URL; empty when absent.             */
+    uint32_t id;                    /**< Numeric achievement ID.                                  */
+    char     name[256];             /**< Achievement title.                                       */
+    char     description[1024];     /**< Achievement description.                                 */
+    uint32_t points;                /**< Point value of the achievement.                          */
+    char     status[16];            /**< "unlocked" or "locked".                                  */
+    uint64_t unlock_time;           /**< Unix timestamp (seconds) when unlocked; 0 if locked.     */
+    char     measured_progress[64]; /**< Progress string for measured achievements (e.g. "5/10");
+                                         empty when not applicable.                               */
+    char     badge_url[512];        /**< Unlocked badge image URL; empty when absent.             */
 } retro_achievement_t;
 
 /* -------------------------------------------------------------------------

--- a/src/integrations/retro-achievements/retro_achievements_monitor.h
+++ b/src/integrations/retro-achievements/retro_achievements_monitor.h
@@ -26,6 +26,8 @@ extern "C" {
  *   - Achievements   : { "type":"achievements",
  *                        "items":[{ "id":1, "name":"...", "points":5,
  *                                   "status":"unlocked",
+ *                                   "unlock_time":1712345678,
+ *                                   "measured_progress":"5/10",
  *                                   "badge_url":"..." }, ...] }
  *   - User           : { "type":"user", "username":"...",
  *                        "display_name":"...", "score":N,
@@ -77,12 +79,15 @@ typedef struct {
  *        server inside an @c "achievements" message.
  */
 typedef struct {
-    uint32_t id;                /**< Numeric achievement ID.                          */
-    char     name[256];         /**< Achievement title.                               */
-    char     description[1024]; /**< Achievement title.                               */
-    uint32_t points;            /**< Point value of the achievement.                  */
-    char     status[16];        /**< "unlocked" or "locked".                          */
-    char     badge_url[512];    /**< Unlocked badge image URL; empty when absent.    */
+    uint32_t id;                       /**< Numeric achievement ID.                                  */
+    char     name[256];                /**< Achievement title.                                       */
+    char     description[1024];        /**< Achievement description.                                 */
+    uint32_t points;                   /**< Point value of the achievement.                          */
+    char     status[16];               /**< "unlocked" or "locked".                                  */
+    uint64_t unlock_time;              /**< Unix timestamp (seconds) when unlocked; 0 if locked.     */
+    char     measured_progress[64];    /**< Progress string for measured achievements (e.g. "5/10");
+                                            empty when not applicable.                               */
+    char     badge_url[512];           /**< Unlocked badge image URL; empty when absent.             */
 } retro_achievement_t;
 
 /* -------------------------------------------------------------------------

--- a/src/io/state.c
+++ b/src/io/state.c
@@ -62,6 +62,10 @@
 #define ACHIEVEMENTS_COUNT_CONFIGURATION_FONT_FACE "source_achievements_count_font_face"
 #define ACHIEVEMENTS_COUNT_CONFIGURATION_FONT_STYLE "source_achievements_count_font_style"
 
+#define CYCLE_LAST_UNLOCKED_DURATION   "cycle_last_unlocked_duration"
+#define CYCLE_LOCKED_EACH_DURATION     "cycle_locked_each_duration"
+#define CYCLE_LOCKED_TOTAL_DURATION    "cycle_locked_total_duration"
+
 /**
  * @brief Global in-memory persisted state.
  *
@@ -684,4 +688,35 @@ void state_free_achievements_count_configuration(achievements_count_configuratio
     }
 
     free_memory((void **)config);
+}
+
+void state_set_achievement_cycle_timings(const achievement_cycle_timings_t *timings) {
+
+    if (!timings) {
+        return;
+    }
+
+    obs_data_set_int(g_state, CYCLE_LAST_UNLOCKED_DURATION, timings->last_unlocked_duration);
+    obs_data_set_int(g_state, CYCLE_LOCKED_EACH_DURATION, timings->locked_achievement_duration);
+    obs_data_set_int(g_state, CYCLE_LOCKED_TOTAL_DURATION, timings->locked_cycle_total_duration);
+
+    save_state(g_state);
+}
+
+achievement_cycle_timings_t *state_get_achievement_cycle_timings(void) {
+
+    int last_unlocked = (int)obs_data_get_int(g_state, CYCLE_LAST_UNLOCKED_DURATION);
+    int locked_each   = (int)obs_data_get_int(g_state, CYCLE_LOCKED_EACH_DURATION);
+    int locked_total  = (int)obs_data_get_int(g_state, CYCLE_LOCKED_TOTAL_DURATION);
+
+    achievement_cycle_timings_t *timings = bzalloc(sizeof(achievement_cycle_timings_t));
+
+    timings->last_unlocked_duration      = last_unlocked > 0 ? last_unlocked
+                                                             : ACHIEVEMENT_CYCLE_DEFAULT_LAST_UNLOCKED_DURATION;
+    timings->locked_achievement_duration = locked_each > 0 ? locked_each
+                                                           : ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_EACH_DURATION;
+    timings->locked_cycle_total_duration = locked_total > 0 ? locked_total
+                                                            : ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_TOTAL_DURATION;
+
+    return timings;
 }

--- a/src/io/state.c
+++ b/src/io/state.c
@@ -65,6 +65,8 @@
 #define CYCLE_LAST_UNLOCKED_DURATION   "cycle_last_unlocked_duration"
 #define CYCLE_LOCKED_EACH_DURATION     "cycle_locked_each_duration"
 #define CYCLE_LOCKED_TOTAL_DURATION    "cycle_locked_total_duration"
+/* Stored as int: 0 = not set (default: enabled), 1 = enabled, 2 = disabled. */
+#define CYCLE_AUTO_CYCLE_ENABLED       "cycle_auto_cycle_enabled"
 
 /**
  * @brief Global in-memory persisted state.
@@ -701,6 +703,17 @@ void state_set_achievement_cycle_timings(const achievement_cycle_timings_t *timi
     obs_data_set_int(g_state, CYCLE_LOCKED_TOTAL_DURATION, timings->locked_cycle_total_duration);
 
     save_state(g_state);
+}
+
+void state_set_auto_cycle_enabled(bool enabled) {
+    obs_data_set_int(g_state, CYCLE_AUTO_CYCLE_ENABLED, enabled ? 1 : 2);
+    save_state(g_state);
+}
+
+bool state_get_auto_cycle_enabled(void) {
+    int value = (int)obs_data_get_int(g_state, CYCLE_AUTO_CYCLE_ENABLED);
+    /* 2 = explicitly disabled; anything else (0 = unset, 1 = enabled) → enabled */
+    return value != 2;
 }
 
 achievement_cycle_timings_t *state_get_achievement_cycle_timings(void) {

--- a/src/io/state.h
+++ b/src/io/state.h
@@ -225,6 +225,22 @@ void state_set_achievements_count_configuration(const achievements_count_configu
 achievements_count_configuration_t *state_get_achievements_count_configuration();
 
 /**
+ * @brief Persist the automatic achievement cycle toggle.
+ *
+ * @param enabled @c true to enable automatic cycling, @c false to disable it.
+ */
+void state_set_auto_cycle_enabled(bool enabled);
+
+/**
+ * @brief Return the persisted automatic cycle state.
+ *
+ * Defaults to @c true when no value has been saved yet.
+ *
+ * @return @c true if automatic cycling is enabled, @c false if it is disabled.
+ */
+bool state_get_auto_cycle_enabled(void);
+
+/**
  * @brief Set the achievement cycle display-duration configuration.
  *
  * Persists the three timing values to the state file so they survive restarts.

--- a/src/io/state.h
+++ b/src/io/state.h
@@ -225,6 +225,28 @@ void state_set_achievements_count_configuration(const achievements_count_configu
 achievements_count_configuration_t *state_get_achievements_count_configuration();
 
 /**
+ * @brief Set the achievement cycle display-duration configuration.
+ *
+ * Persists the three timing values to the state file so they survive restarts.
+ *
+ * @param timings Timing values to store. May be NULL (no-op).
+ */
+void state_set_achievement_cycle_timings(const achievement_cycle_timings_t *timings);
+
+/**
+ * @brief Get the stored achievement cycle display-duration configuration.
+ *
+ * Returns a newly allocated structure with defaults applied for any value that
+ * has not been persisted yet:
+ * - last_unlocked_duration:      45 s
+ * - locked_achievement_duration: 30 s
+ * - locked_cycle_total_duration: 120 s
+ *
+ * @return Newly allocated timings structure. Caller must free with bfree().
+ */
+achievement_cycle_timings_t *state_get_achievement_cycle_timings(void);
+
+/**
  * @brief Clear all in-memory state (and typically any persisted state).
  *
  * After calling this, all getters are expected to return NULL until new values

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,9 @@ bool obs_module_load(void) {
         }
     }
 
+    /* Apply the persisted auto-cycle toggle (defaults to enabled when not yet saved) */
+    achievement_cycle_set_auto_cycle(state_get_auto_cycle_enabled());
+
     xbox_achievement_name_source_register();
     xbox_achievement_description_source_register();
     xbox_achievement_icon_source_register();

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 
 #include "sources/common/achievement_cycle.h"
 #include "ui/xbox_account_config.h"
+#include "ui/achievement_tracker_config.h"
 #include "sources/gamerpic.h"
 #include "sources/game_cover.h"
 #include "sources/gamerscore.h"
@@ -24,6 +25,7 @@ bool obs_module_load(void) {
     io_load();
 
     xbox_account_config_register();
+    achievement_tracker_config_register();
     monitoring_start();
 
     xbox_gamerpic_source_register();
@@ -33,6 +35,17 @@ bool obs_module_load(void) {
 
     /* Initialize the shared achievement display cycle before registering achievement sources */
     achievement_cycle_init();
+
+    /* Apply any user-configured timing values persisted from a previous session */
+    {
+        achievement_cycle_timings_t *timings = state_get_achievement_cycle_timings();
+        if (timings) {
+            achievement_cycle_set_timings((float)timings->last_unlocked_duration,
+                                          (float)timings->locked_achievement_duration,
+                                          (float)timings->locked_cycle_total_duration);
+            bfree(timings);
+        }
+    }
 
     xbox_achievement_name_source_register();
     xbox_achievement_description_source_register();
@@ -46,6 +59,7 @@ bool obs_module_load(void) {
 
 void obs_module_unload(void) {
     xbox_account_config_unregister();
+    achievement_tracker_config_unregister();
 
     achievement_cycle_destroy();
     image_cleanup();

--- a/src/sources/common/achievement_cycle.c
+++ b/src/sources/common/achievement_cycle.c
@@ -84,11 +84,16 @@ static void notify_subscribers(const achievement_t *achievement) {
 }
 
 /**
- * @brief Reset the display cycle to show the last unlocked achievement.
+ * @brief Reset the display cycle to show the last unlocked achievement,
+ *        or a random locked achievement if none have been unlocked yet.
  *
  * Finds the last unlocked achievement and resets all timers to start
  * a fresh display cycle. Makes a deep copy of the achievement to avoid
  * dangling pointers when the session changes.
+ *
+ * If there are no unlocked achievements but there are locked ones,
+ * immediately starts the locked rotation so sources display something
+ * straight away rather than staying blank for LAST_UNLOCKED_DISPLAY_DURATION.
  */
 static void reset_display_cycle(void) {
 
@@ -107,14 +112,37 @@ static void reset_display_cycle(void) {
         g_last_unlocked = copy_achievement(latest_unlocked);
     }
 
+    if (g_last_unlocked) {
+        /* There is a last-unlocked achievement — start with the normal phase */
+        g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
+        g_phase_timer          = LAST_UNLOCKED_DISPLAY_DURATION;
+        g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+
+        notify_subscribers(g_last_unlocked);
+    } else {
+        /* No unlocked achievements yet — immediately show a random locked one
+         * so sources are never blank at session start. */
+        const achievement_t *locked = get_random_locked_achievement(achievements);
+        if (locked) {
+            g_last_unlocked = copy_achievement(locked);
+
+            g_display_phase        = DISPLAY_PHASE_LOCKED_ROTATION;
+            g_phase_timer          = LOCKED_CYCLE_TOTAL_DURATION;
+            g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+
+            obs_log(LOG_DEBUG, "Achievement Cycle: No unlocked achievements, showing random locked: %s", locked->name);
+            notify_subscribers(g_last_unlocked);
+        } else {
+            /* No achievements at all (empty list) — clear the display */
+            g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
+            g_phase_timer          = LAST_UNLOCKED_DISPLAY_DURATION;
+            g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+
+            notify_subscribers(NULL);
+        }
+    }
+
     free_achievement(&achievements);
-
-    /* Reset display cycle to show the last unlocked achievement */
-    g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
-    g_phase_timer          = LAST_UNLOCKED_DISPLAY_DURATION;
-    g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
-
-    notify_subscribers(g_last_unlocked);
 }
 
 //  --------------------------------------------------------------------------------------------------------------------
@@ -151,7 +179,7 @@ static void on_game_played(const game_t *game) {
     g_session_ready = false;
 
     /* Clear the display while icons are being prefetched */
-    g_last_unlocked = NULL;
+    free_achievement(&g_last_unlocked);
     notify_subscribers(NULL);
 }
 

--- a/src/sources/common/achievement_cycle.c
+++ b/src/sources/common/achievement_cycle.c
@@ -56,6 +56,9 @@ static int g_subscriber_count = 0;
 /** Whether the module has been initialized. */
 static bool g_initialized = false;
 
+/** Whether the automatic display cycle is active (true by default). */
+static bool g_auto_cycle_enabled = true;
+
 /**
  * @brief Index of the currently displayed achievement in the sorted full list.
  *
@@ -273,6 +276,51 @@ static void navigate(int direction) {
     free_achievement(&achievements);
 }
 
+/**
+ * @brief Jump directly to a specific index in the sorted achievement list.
+ *
+ * @param target_index Absolute index to jump to (0-based, from sorted list).
+ */
+static void navigate_to_index(int target_index) {
+
+    if (!g_initialized || !g_session_ready) {
+        return;
+    }
+
+    achievement_t *achievements = copy_achievement(monitoring_get_current_game_achievements());
+    if (!achievements) {
+        return;
+    }
+
+    int count = count_achievements(achievements);
+    if (count == 0 || target_index < 0 || target_index >= count) {
+        free_achievement(&achievements);
+        return;
+    }
+
+    sort_achievements(&achievements);
+
+    /* Walk the linked list to the target index. */
+    const achievement_t *target = achievements;
+    for (int i = 0; i < target_index && target->next; i++) {
+        target = target->next;
+    }
+
+    g_nav_index = target_index;
+
+    free_achievement(&g_last_unlocked);
+    g_last_unlocked = copy_achievement(target);
+
+    g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
+    g_phase_timer          = g_last_unlocked_duration;
+    g_locked_display_timer = g_locked_each_duration;
+
+    obs_log(LOG_DEBUG, "Achievement Cycle: Jumped to index %d: %s", g_nav_index, target->name ? target->name : "(null)");
+
+    notify_subscribers(g_last_unlocked);
+    free_achievement(&achievements);
+}
+
 //  --------------------------------------------------------------------------------------------------------------------
 //  Public API
 //  --------------------------------------------------------------------------------------------------------------------
@@ -362,7 +410,7 @@ void achievement_cycle_unsubscribe(achievement_cycle_callback_t callback) {
 
 void achievement_cycle_tick(float seconds) {
 
-    if (!g_initialized || !g_session_ready) {
+    if (!g_initialized || !g_session_ready || !g_auto_cycle_enabled) {
         return;
     }
 
@@ -462,6 +510,67 @@ void achievement_cycle_navigate_next(void) {
 
 void achievement_cycle_navigate_previous(void) {
     navigate(-1);
+}
+
+void achievement_cycle_navigate_first_locked(void) {
+
+    if (!g_initialized || !g_session_ready) {
+        return;
+    }
+
+    achievement_t *achievements = copy_achievement(monitoring_get_current_game_achievements());
+    if (!achievements) {
+        return;
+    }
+
+    sort_achievements(&achievements);
+
+    /* In the sorted list, unlocked achievements come first. The first locked
+     * achievement is therefore at index == count_unlocked_achievements(). */
+    int first_locked_index = count_unlocked_achievements(achievements);
+    int total              = count_achievements(achievements);
+
+    free_achievement(&achievements);
+
+    if (first_locked_index >= total) {
+        obs_log(LOG_DEBUG, "Achievement Cycle: No locked achievements to jump to");
+        return;
+    }
+
+    obs_log(LOG_DEBUG, "Achievement Cycle: Jumping to first locked achievement at index %d", first_locked_index);
+    navigate_to_index(first_locked_index);
+}
+
+void achievement_cycle_navigate_first_unlocked(void) {
+
+    if (!g_initialized || !g_session_ready) {
+        return;
+    }
+
+    achievement_t *achievements = copy_achievement(monitoring_get_current_game_achievements());
+    if (!achievements) {
+        return;
+    }
+
+    int unlocked_count = count_unlocked_achievements(achievements);
+    free_achievement(&achievements);
+
+    if (unlocked_count == 0) {
+        obs_log(LOG_DEBUG, "Achievement Cycle: No unlocked achievements to jump to");
+        return;
+    }
+
+    obs_log(LOG_DEBUG, "Achievement Cycle: Jumping to first unlocked achievement (index 0)");
+    navigate_to_index(0);
+}
+
+void achievement_cycle_set_auto_cycle(bool enabled) {
+    g_auto_cycle_enabled = enabled;
+    obs_log(LOG_DEBUG, "Achievement Cycle: auto-cycle %s", enabled ? "enabled" : "disabled");
+}
+
+bool achievement_cycle_is_auto_cycle_enabled(void) {
+    return g_auto_cycle_enabled;
 }
 
 void achievement_cycle_set_timings(float last_unlocked_secs, float locked_each_secs, float locked_total_secs) {

--- a/src/sources/common/achievement_cycle.c
+++ b/src/sources/common/achievement_cycle.c
@@ -8,17 +8,19 @@
 
 #include <stdlib.h>
 
-/** Duration to show the last unlocked achievement (seconds). */
-#define LAST_UNLOCKED_DISPLAY_DURATION 45.0f
-
-/** Duration to show each random locked achievement (seconds). */
-#define LOCKED_ACHIEVEMENT_DISPLAY_DURATION 30.0f
-
-/** Total duration to cycle through locked achievements (seconds). */
-#define LOCKED_CYCLE_TOTAL_DURATION 120.0f
+#include "common/types.h"
 
 /** Maximum number of subscribers that can be registered. */
 #define MAX_SUBSCRIBERS 16
+
+/** Configurable duration to show the last unlocked achievement (seconds). */
+static float g_last_unlocked_duration = ACHIEVEMENT_CYCLE_DEFAULT_LAST_UNLOCKED_DURATION;
+
+/** Configurable duration to show each random locked achievement (seconds). */
+static float g_locked_each_duration = ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_EACH_DURATION;
+
+/** Configurable total duration to cycle through locked achievements (seconds). */
+static float g_locked_total_duration = ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_TOTAL_DURATION;
 
 /**
  * @brief Display cycle phase for achievement rotation.
@@ -34,10 +36,10 @@ typedef enum display_cycle_phase {
 static display_cycle_phase_t g_display_phase = DISPLAY_PHASE_LAST_UNLOCKED;
 
 /** Time remaining in the current display phase (seconds). */
-static float g_phase_timer = LAST_UNLOCKED_DISPLAY_DURATION;
+static float g_phase_timer = ACHIEVEMENT_CYCLE_DEFAULT_LAST_UNLOCKED_DURATION;
 
 /** Time remaining for the current locked achievement display (seconds). */
-static float g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+static float g_locked_display_timer = ACHIEVEMENT_CYCLE_DEFAULT_LOCKED_EACH_DURATION;
 
 /** The last unlocked achievement (owned by this module). */
 static achievement_t *g_last_unlocked = NULL;
@@ -53,6 +55,15 @@ static int g_subscriber_count = 0;
 
 /** Whether the module has been initialized. */
 static bool g_initialized = false;
+
+/**
+ * @brief Index of the currently displayed achievement in the sorted full list.
+ *
+ * Used by the manual navigation functions to keep track of position across
+ * calls.  Reset to 0 whenever the achievement set changes (game change,
+ * session reset, etc.).
+ */
+static int g_nav_index = 0;
 
 /**
  * @brief Whether the session is fully ready (achievements fetched + icons prefetched).
@@ -93,13 +104,16 @@ static void notify_subscribers(const achievement_t *achievement) {
  *
  * If there are no unlocked achievements but there are locked ones,
  * immediately starts the locked rotation so sources display something
- * straight away rather than staying blank for LAST_UNLOCKED_DISPLAY_DURATION.
+ * straight away rather than staying blank for g_last_unlocked_duration.
  */
 static void reset_display_cycle(void) {
 
     if (!g_session_ready) {
         return;
     }
+
+    /* Reset the navigation index so manual navigation restarts from a clean position */
+    g_nav_index = 0;
 
     /* Free the old cached copy */
     free_achievement(&g_last_unlocked);
@@ -115,8 +129,8 @@ static void reset_display_cycle(void) {
     if (g_last_unlocked) {
         /* There is a last-unlocked achievement — start with the normal phase */
         g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
-        g_phase_timer          = LAST_UNLOCKED_DISPLAY_DURATION;
-        g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+        g_phase_timer          = g_last_unlocked_duration;
+        g_locked_display_timer = g_locked_each_duration;
 
         notify_subscribers(g_last_unlocked);
     } else {
@@ -127,16 +141,16 @@ static void reset_display_cycle(void) {
             g_last_unlocked = copy_achievement(locked);
 
             g_display_phase        = DISPLAY_PHASE_LOCKED_ROTATION;
-            g_phase_timer          = LOCKED_CYCLE_TOTAL_DURATION;
-            g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+            g_phase_timer          = g_locked_total_duration;
+            g_locked_display_timer = g_locked_each_duration;
 
             obs_log(LOG_DEBUG, "Achievement Cycle: No unlocked achievements, showing random locked: %s", locked->name);
             notify_subscribers(g_last_unlocked);
         } else {
             /* No achievements at all (empty list) — clear the display */
             g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
-            g_phase_timer          = LAST_UNLOCKED_DISPLAY_DURATION;
-            g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+            g_phase_timer          = g_last_unlocked_duration;
+            g_locked_display_timer = g_locked_each_duration;
 
             notify_subscribers(NULL);
         }
@@ -203,6 +217,63 @@ static void on_session_ready(void) {
 }
 
 //  --------------------------------------------------------------------------------------------------------------------
+//  Manual navigation helpers
+//  --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * @brief Move the display to an adjacent achievement in the sorted list.
+ *
+ * @param direction +1 for next, -1 for previous.
+ */
+static void navigate(int direction) {
+
+    if (!g_initialized || !g_session_ready) {
+        return;
+    }
+
+    achievement_t *achievements = copy_achievement(monitoring_get_current_game_achievements());
+    if (!achievements) {
+        return;
+    }
+
+    int count = count_achievements(achievements);
+    if (count == 0) {
+        free_achievement(&achievements);
+        return;
+    }
+
+    /* Sort for a stable, deterministic traversal order (unlocked first, then
+     * by timestamp descending; locked achievements follow). */
+    sort_achievements(&achievements);
+
+    /* Advance or rewind, wrapping at the boundaries. */
+    g_nav_index = ((g_nav_index + direction) % count + count) % count;
+
+    /* Walk the linked list to the target index. */
+    const achievement_t *target = achievements;
+    for (int i = 0; i < g_nav_index && target->next; i++) {
+        target = target->next;
+    }
+
+    /* Update the cached copy and reset the phase so the achievement is
+     * visible for a full interval before the automatic cycle resumes. */
+    free_achievement(&g_last_unlocked);
+    g_last_unlocked = copy_achievement(target);
+
+    g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
+    g_phase_timer          = g_last_unlocked_duration;
+    g_locked_display_timer = g_locked_each_duration;
+
+    obs_log(LOG_DEBUG,
+            "Achievement Cycle: Manual navigation to index %d: %s",
+            g_nav_index,
+            target->name ? target->name : "(null)");
+
+    notify_subscribers(g_last_unlocked);
+    free_achievement(&achievements);
+}
+
+//  --------------------------------------------------------------------------------------------------------------------
 //  Public API
 //  --------------------------------------------------------------------------------------------------------------------
 
@@ -213,8 +284,8 @@ void achievement_cycle_init(void) {
     }
 
     g_display_phase        = DISPLAY_PHASE_LAST_UNLOCKED;
-    g_phase_timer          = LAST_UNLOCKED_DISPLAY_DURATION;
-    g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+    g_phase_timer          = g_last_unlocked_duration;
+    g_locked_display_timer = g_locked_each_duration;
     g_last_unlocked        = NULL;
     g_current_achievement  = NULL;
     g_subscriber_count     = 0;
@@ -311,8 +382,8 @@ void achievement_cycle_tick(float seconds) {
             obs_log(LOG_DEBUG, "Achievement Cycle: Switching to locked achievements rotation");
             if (count_locked_achievements(achievements) > 0) {
                 g_display_phase        = DISPLAY_PHASE_LOCKED_ROTATION;
-                g_phase_timer          = LOCKED_CYCLE_TOTAL_DURATION;
-                g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+                g_phase_timer          = g_locked_total_duration;
+                g_locked_display_timer = g_locked_each_duration;
 
                 const achievement_t *locked = get_random_locked_achievement(achievements);
 
@@ -327,7 +398,7 @@ void achievement_cycle_tick(float seconds) {
                 }
             } else {
                 obs_log(LOG_DEBUG, "Achievement Cycle: No locked achievements, keeping last unlocked");
-                g_phase_timer = LAST_UNLOCKED_DISPLAY_DURATION;
+                g_phase_timer = g_last_unlocked_duration;
             }
         }
         break;
@@ -336,7 +407,7 @@ void achievement_cycle_tick(float seconds) {
         g_locked_display_timer -= seconds;
 
         if (g_locked_display_timer <= 0.0f) {
-            g_locked_display_timer = LOCKED_ACHIEVEMENT_DISPLAY_DURATION;
+            g_locked_display_timer = g_locked_each_duration;
 
             const achievement_t *locked = get_random_locked_achievement(achievements);
             if (locked) {
@@ -349,15 +420,25 @@ void achievement_cycle_tick(float seconds) {
         if (g_phase_timer <= 0.0f) {
             obs_log(LOG_DEBUG, "Achievement Cycle: Locked achievements rotation complete");
             g_display_phase = DISPLAY_PHASE_LAST_UNLOCKED;
-            g_phase_timer   = LAST_UNLOCKED_DISPLAY_DURATION;
+            g_phase_timer   = g_last_unlocked_duration;
 
-            if (g_last_unlocked) {
+            /* Always re-derive the last unlocked achievement from the live list.
+             * g_last_unlocked is overwritten with locked achievements during the
+             * rotation phase and cannot be trusted to hold the correct value here. */
+            free_achievement(&g_last_unlocked);
+            const achievement_t *latest_unlocked = find_latest_unlocked_achievement(achievements);
+            if (latest_unlocked) {
+                g_last_unlocked = copy_achievement(latest_unlocked);
                 notify_subscribers(g_last_unlocked);
             } else {
-                const achievement_t *latest_unlocked = find_latest_unlocked_achievement(achievements);
-                if (latest_unlocked) {
-                    g_last_unlocked = copy_achievement(latest_unlocked);
+                /* Still no unlocked achievements — keep showing a random locked one
+                 * rather than going blank for the entire unlocked phase. */
+                const achievement_t *locked = get_random_locked_achievement(achievements);
+                if (locked) {
+                    g_last_unlocked = copy_achievement(locked);
                     notify_subscribers(g_last_unlocked);
+                } else {
+                    notify_subscribers(NULL);
                 }
             }
         }
@@ -373,4 +454,30 @@ const achievement_t *achievement_cycle_get_current(void) {
 
 const achievement_t *achievement_cycle_get_last_unlocked(void) {
     return g_last_unlocked;
+}
+
+void achievement_cycle_navigate_next(void) {
+    navigate(+1);
+}
+
+void achievement_cycle_navigate_previous(void) {
+    navigate(-1);
+}
+
+void achievement_cycle_set_timings(float last_unlocked_secs, float locked_each_secs, float locked_total_secs) {
+
+    g_last_unlocked_duration = last_unlocked_secs >= ACHIEVEMENT_CYCLE_MIN_DURATION ? last_unlocked_secs
+                                                                                    : ACHIEVEMENT_CYCLE_MIN_DURATION;
+
+    g_locked_each_duration = locked_each_secs >= ACHIEVEMENT_CYCLE_MIN_DURATION ? locked_each_secs
+                                                                                : ACHIEVEMENT_CYCLE_MIN_DURATION;
+
+    /* The total locked rotation must fit at least one locked achievement. */
+    g_locked_total_duration = locked_total_secs >= g_locked_each_duration ? locked_total_secs : g_locked_each_duration;
+
+    obs_log(LOG_DEBUG,
+            "Achievement Cycle: timings updated — last_unlocked=%.0fs, locked_each=%.0fs, locked_total=%.0fs",
+            g_last_unlocked_duration,
+            g_locked_each_duration,
+            g_locked_total_duration);
 }

--- a/src/sources/common/achievement_cycle.h
+++ b/src/sources/common/achievement_cycle.h
@@ -104,6 +104,37 @@ const achievement_t *achievement_cycle_get_current(void);
  */
 const achievement_t *achievement_cycle_get_last_unlocked(void);
 
+/**
+ * @brief Update the display-duration settings used by the achievement cycle.
+ *
+ * Changes take effect at the start of the next phase; currently-running timers
+ * are not truncated.  Values <= 0 are silently clamped to 1 second.
+ *
+ * @param last_unlocked_secs  Seconds to show the last-unlocked achievement.
+ * @param locked_each_secs    Seconds to show each random locked achievement.
+ * @param locked_total_secs   Total seconds to spend in the locked-rotation phase.
+ */
+void achievement_cycle_set_timings(float last_unlocked_secs, float locked_each_secs, float locked_total_secs);
+
+/**
+ * @brief Advance to the next achievement in the sorted list.
+ *
+ * Immediately displays the next achievement (wrapping around at the end of the
+ * list) and resets the phase timer so it stays visible for a full interval.
+ * No-op if the session is not ready or no achievements are available.
+ */
+void achievement_cycle_navigate_next(void);
+
+/**
+ * @brief Go back to the previous achievement in the sorted list.
+ *
+ * Immediately displays the previous achievement (wrapping around at the
+ * beginning of the list) and resets the phase timer so it stays visible for a
+ * full interval.  No-op if the session is not ready or no achievements are
+ * available.
+ */
+void achievement_cycle_navigate_previous(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sources/common/achievement_cycle.h
+++ b/src/sources/common/achievement_cycle.h
@@ -135,6 +135,47 @@ void achievement_cycle_navigate_next(void);
  */
 void achievement_cycle_navigate_previous(void);
 
+/**
+ * @brief Jump directly to the first locked achievement in the sorted list.
+ *
+ * The sorted order places unlocked achievements first; locked achievements
+ * follow. This function jumps to the first entry in the locked section.
+ * No-op if the session is not ready, there are no achievements, or all
+ * achievements are already unlocked.
+ */
+void achievement_cycle_navigate_first_locked(void);
+
+/**
+ * @brief Jump directly to the first unlocked achievement in the sorted list.
+ *
+ * Equivalent to jumping to index 0 of the sorted list, which holds the most
+ * recently unlocked achievement.
+ * No-op if the session is not ready, there are no achievements, or no
+ * achievement has been unlocked yet.
+ */
+void achievement_cycle_navigate_first_unlocked(void);
+
+/**
+ * @brief Enable or disable the automatic achievement rotation.
+ *
+ * When disabled, @ref achievement_cycle_tick is a no-op: the cycle freezes on
+ * the achievement currently being displayed.  Manual navigation via
+ * @ref achievement_cycle_navigate_next / @ref achievement_cycle_navigate_previous
+ * remains functional.
+ *
+ * The setting defaults to @c true and survives until the next call.
+ *
+ * @param enabled @c true to resume automatic cycling, @c false to pause it.
+ */
+void achievement_cycle_set_auto_cycle(bool enabled);
+
+/**
+ * @brief Return whether the automatic achievement rotation is currently active.
+ *
+ * @return @c true if the cycle advances automatically, @c false if it is paused.
+ */
+bool achievement_cycle_is_auto_cycle_enabled(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ui/achievement_tracker_config.cpp
+++ b/src/ui/achievement_tracker_config.cpp
@@ -9,6 +9,7 @@
 #include <QDialogButtonBox>
 #include <QFormLayout>
 #include <QFrame>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QPointer>
 #include <QPushButton>
@@ -25,8 +26,11 @@ extern "C" {
 // Hotkey IDs
 // ----------------------------------------------------------------------------
 
-static obs_hotkey_id g_hotkey_next_id     = OBS_INVALID_HOTKEY_ID;
-static obs_hotkey_id g_hotkey_previous_id = OBS_INVALID_HOTKEY_ID;
+static obs_hotkey_id g_hotkey_next_id           = OBS_INVALID_HOTKEY_ID;
+static obs_hotkey_id g_hotkey_previous_id       = OBS_INVALID_HOTKEY_ID;
+static obs_hotkey_id g_hotkey_toggle_cycle_id   = OBS_INVALID_HOTKEY_ID;
+static obs_hotkey_id g_hotkey_first_locked_id   = OBS_INVALID_HOTKEY_ID;
+static obs_hotkey_id g_hotkey_first_unlocked_id = OBS_INVALID_HOTKEY_ID;
 
 // ----------------------------------------------------------------------------
 // Hotkey callbacks
@@ -48,6 +52,35 @@ static void on_previous_achievement(void *, obs_hotkey_id, obs_hotkey_t *, bool 
 
     obs_log(LOG_DEBUG, "Achievement Tracker: hotkey 'Previous Achievement' pressed");
     achievement_cycle_navigate_previous();
+}
+
+static void on_first_locked_achievement(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
+    if (!pressed) {
+        return;
+    }
+
+    obs_log(LOG_DEBUG, "Achievement Tracker: hotkey 'First Locked Achievement' pressed");
+    achievement_cycle_navigate_first_locked();
+}
+
+static void on_first_unlocked_achievement(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
+    if (!pressed) {
+        return;
+    }
+
+    obs_log(LOG_DEBUG, "Achievement Tracker: hotkey 'First Unlocked Achievement' pressed");
+    achievement_cycle_navigate_first_unlocked();
+}
+
+static void on_toggle_auto_cycle(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
+    if (!pressed) {
+        return;
+    }
+
+    const bool enabled = !achievement_cycle_is_auto_cycle_enabled();
+    achievement_cycle_set_auto_cycle(enabled);
+    state_set_auto_cycle_enabled(enabled);
+    obs_log(LOG_INFO, "Achievement Tracker: auto-cycle toggled %s", enabled ? "on" : "off");
 }
 
 // ----------------------------------------------------------------------------
@@ -125,6 +158,7 @@ static QString format_binding(obs_hotkey_id id) {
         {"RIGHT", "→"},
         {"UP", "↑"},
         {"DOWN", "↓"},
+        {"SPACE", "Space"},
         {nullptr, nullptr},
     };
     for (int i = 0; key_map[i].from; ++i) {
@@ -165,25 +199,73 @@ class AchievementTrackerDialog final : public QDialog {
         hotkeysHelp->setWordWrap(true);
         hotkeysHelp->setText(
             "Keyboard shortcuts for cycling through achievements. "
-            "To reconfigure, open OBS Settings \u2192 Hotkeys and search for \"Achievement Tracker\".");
+            "To reconfigure, open OBS Settings \u2192 Hotkeys and search for \"Achievement Tracker\".\n\n"
+            "On macOS, global hotkeys require Input Monitoring permission "
+            "(System Settings \u2192 Privacy & Security \u2192 Input Monitoring). "
+            "Use the buttons below as a fallback when that permission is not granted.");
 
         auto *hotkeysForm = new QFormLayout();
         hotkeysForm->setLabelAlignment(Qt::AlignLeft);
         hotkeysForm->setVerticalSpacing(6);
 
-        m_prevBinding = new QLabel(this);
-        m_nextBinding = new QLabel(this);
+        m_prevBinding          = new QLabel(this);
+        m_nextBinding          = new QLabel(this);
+        m_firstUnlockedBinding = new QLabel(this);
+        m_firstLockedBinding   = new QLabel(this);
+        m_toggleCycleBinding   = new QLabel(this);
+        m_autoCycleState       = new QLabel(this);
         m_prevBinding->setTextInteractionFlags(Qt::TextSelectableByMouse);
         m_nextBinding->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        m_firstUnlockedBinding->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        m_firstLockedBinding->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        m_toggleCycleBinding->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
         hotkeysForm->addRow("Previous Achievement", m_prevBinding);
         hotkeysForm->addRow("Next Achievement", m_nextBinding);
+        hotkeysForm->addRow("First Unlocked Achievement", m_firstUnlockedBinding);
+        hotkeysForm->addRow("First Locked Achievement", m_firstLockedBinding);
+        hotkeysForm->addRow("Toggle Auto Cycle", m_toggleCycleBinding);
+        hotkeysForm->addRow("Auto Cycle Status", m_autoCycleState);
+
+        // Manual navigation buttons — fallback when global hotkeys are unavailable.
+        auto *navLayout       = new QHBoxLayout();
+        m_prevButton          = new QPushButton("← Previous", this);
+        m_nextButton          = new QPushButton("Next →", this);
+        m_firstUnlockedButton = new QPushButton("⊤ First Unlocked", this);
+        m_firstLockedButton   = new QPushButton("⊥ First Locked", this);
+        m_toggleCycleButton   = new QPushButton("Toggle Cycle", this);
+        m_prevButton->setToolTip("Show the previous achievement");
+        m_nextButton->setToolTip("Show the next achievement");
+        m_firstUnlockedButton->setToolTip("Jump to the first (most recent) unlocked achievement");
+        m_firstLockedButton->setToolTip("Jump to the first locked achievement");
+        m_toggleCycleButton->setToolTip("Toggle the automatic achievement rotation on/off");
+        navLayout->addWidget(m_prevButton);
+        navLayout->addWidget(m_nextButton);
+        navLayout->addWidget(m_firstUnlockedButton);
+        navLayout->addWidget(m_firstLockedButton);
+        navLayout->addWidget(m_toggleCycleButton);
+
+        connect(m_prevButton, &QPushButton::clicked, this, []() { achievement_cycle_navigate_previous(); });
+        connect(m_nextButton, &QPushButton::clicked, this, []() { achievement_cycle_navigate_next(); });
+        connect(m_firstUnlockedButton, &QPushButton::clicked, this, []() {
+            achievement_cycle_navigate_first_unlocked();
+        });
+        connect(m_firstLockedButton, &QPushButton::clicked, this, []() { achievement_cycle_navigate_first_locked(); });
+        connect(m_toggleCycleButton, &QPushButton::clicked, this, [this]() {
+            const bool enabled = !achievement_cycle_is_auto_cycle_enabled();
+            achievement_cycle_set_auto_cycle(enabled);
+            state_set_auto_cycle_enabled(enabled);
+            obs_log(LOG_INFO, "Achievement Tracker: auto-cycle toggled %s via dialog", enabled ? "on" : "off");
+            refreshBindings();
+        });
 
         rootLayout->addWidget(hotkeysLabel);
         rootLayout->addSpacing(4);
         rootLayout->addWidget(hotkeysHelp);
         rootLayout->addSpacing(6);
         rootLayout->addLayout(hotkeysForm);
+        rootLayout->addSpacing(6);
+        rootLayout->addLayout(navLayout);
 
         // ---- Separator -------------------------------------------------------
         auto *separator = new QFrame(this);
@@ -256,6 +338,10 @@ class AchievementTrackerDialog final : public QDialog {
     void refreshBindings() {
         m_prevBinding->setText(format_binding(g_hotkey_previous_id));
         m_nextBinding->setText(format_binding(g_hotkey_next_id));
+        m_firstUnlockedBinding->setText(format_binding(g_hotkey_first_unlocked_id));
+        m_firstLockedBinding->setText(format_binding(g_hotkey_first_locked_id));
+        m_toggleCycleBinding->setText(format_binding(g_hotkey_toggle_cycle_id));
+        m_autoCycleState->setText(achievement_cycle_is_auto_cycle_enabled() ? "On" : "Off");
     }
 
     void loadTimings() {
@@ -293,6 +379,15 @@ class AchievementTrackerDialog final : public QDialog {
 
     QLabel      *m_prevBinding;
     QLabel      *m_nextBinding;
+    QLabel      *m_firstUnlockedBinding;
+    QLabel      *m_firstLockedBinding;
+    QLabel      *m_toggleCycleBinding;
+    QLabel      *m_autoCycleState;
+    QPushButton *m_prevButton;
+    QPushButton *m_nextButton;
+    QPushButton *m_firstUnlockedButton;
+    QPushButton *m_firstLockedButton;
+    QPushButton *m_toggleCycleButton;
     QSpinBox    *m_lastUnlockedSpin;
     QSpinBox    *m_lockedEachSpin;
     QSpinBox    *m_lockedTotalSpin;
@@ -334,16 +429,38 @@ extern "C" void achievement_tracker_config_register(void) {
                                                     on_next_achievement,
                                                     nullptr);
 
+    g_hotkey_first_unlocked_id = obs_hotkey_register_frontend("achievement_tracker.first_unlocked_achievement",
+                                                              "Achievement Tracker: First Unlocked Achievement",
+                                                              on_first_unlocked_achievement,
+                                                              nullptr);
+
+    g_hotkey_first_locked_id = obs_hotkey_register_frontend("achievement_tracker.first_locked_achievement",
+                                                            "Achievement Tracker: First Locked Achievement",
+                                                            on_first_locked_achievement,
+                                                            nullptr);
+
+    g_hotkey_toggle_cycle_id = obs_hotkey_register_frontend("achievement_tracker.toggle_auto_cycle",
+                                                            "Achievement Tracker: Toggle Auto Cycle",
+                                                            on_toggle_auto_cycle,
+                                                            nullptr);
+
     // Apply default bindings only when the user has not yet configured the hotkey.
     load_default_binding(g_hotkey_previous_id, "OBS_KEY_LEFT", /*shift=*/true, /*ctrl=*/false, /*alt=*/false);
     load_default_binding(g_hotkey_next_id, "OBS_KEY_RIGHT", /*shift=*/true, /*ctrl=*/false, /*alt=*/false);
+    load_default_binding(g_hotkey_first_unlocked_id, "OBS_KEY_UP", /*shift=*/true, /*ctrl=*/false, /*alt=*/false);
+    load_default_binding(g_hotkey_first_locked_id, "OBS_KEY_DOWN", /*shift=*/true, /*ctrl=*/false, /*alt=*/false);
+    load_default_binding(g_hotkey_toggle_cycle_id, "OBS_KEY_SPACE", /*shift=*/true, /*ctrl=*/false, /*alt=*/false);
 
     obs_frontend_add_tools_menu_item("Achievement Tracker", show_achievement_tracker_dialog, nullptr);
 
     obs_log(LOG_INFO,
-            "Achievement Tracker: hotkeys registered (previous=%llu, next=%llu)",
+            "Achievement Tracker: hotkeys registered "
+            "(previous=%llu, next=%llu, first_unlocked=%llu, first_locked=%llu, toggle_cycle=%llu)",
             (unsigned long long)g_hotkey_previous_id,
-            (unsigned long long)g_hotkey_next_id);
+            (unsigned long long)g_hotkey_next_id,
+            (unsigned long long)g_hotkey_first_unlocked_id,
+            (unsigned long long)g_hotkey_first_locked_id,
+            (unsigned long long)g_hotkey_toggle_cycle_id);
 }
 
 extern "C" void achievement_tracker_config_unregister(void) {

--- a/src/ui/achievement_tracker_config.cpp
+++ b/src/ui/achievement_tracker_config.cpp
@@ -1,0 +1,356 @@
+#include "ui/achievement_tracker_config.h"
+
+#include <obs-frontend-api.h>
+#include <obs-hotkey.h>
+#include <obs-module.h>
+#include <diagnostics/log.h>
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QFrame>
+#include <QLabel>
+#include <QPointer>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QVBoxLayout>
+#include <QWidget>
+
+extern "C" {
+#include "sources/common/achievement_cycle.h"
+#include "io/state.h"
+}
+
+// ----------------------------------------------------------------------------
+// Hotkey IDs
+// ----------------------------------------------------------------------------
+
+static obs_hotkey_id g_hotkey_next_id     = OBS_INVALID_HOTKEY_ID;
+static obs_hotkey_id g_hotkey_previous_id = OBS_INVALID_HOTKEY_ID;
+
+// ----------------------------------------------------------------------------
+// Hotkey callbacks
+// ----------------------------------------------------------------------------
+
+static void on_next_achievement(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
+    if (!pressed) {
+        return;
+    }
+
+    obs_log(LOG_DEBUG, "Achievement Tracker: hotkey 'Next Achievement' pressed");
+    achievement_cycle_navigate_next();
+}
+
+static void on_previous_achievement(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
+    if (!pressed) {
+        return;
+    }
+
+    obs_log(LOG_DEBUG, "Achievement Tracker: hotkey 'Previous Achievement' pressed");
+    achievement_cycle_navigate_previous();
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief Load a single-binding default (modifier + key) for a hotkey if the
+ *        hotkey currently has no saved bindings.
+ */
+static void load_default_binding(obs_hotkey_id id, const char *key_name, bool shift, bool ctrl, bool alt) {
+
+    obs_data_array_t *current     = obs_hotkey_save(id);
+    const bool        has_binding = obs_data_array_count(current) > 0;
+    obs_data_array_release(current);
+
+    if (has_binding) {
+        return; /* User already configured this hotkey — respect their choice. */
+    }
+
+    obs_data_array_t *defaults = obs_data_array_create();
+    obs_data_t       *binding  = obs_data_create();
+
+    obs_data_set_string(binding, "key", key_name);
+    obs_data_set_bool(binding, "shift", shift);
+    obs_data_set_bool(binding, "control", ctrl);
+    obs_data_set_bool(binding, "alt", alt);
+    obs_data_set_bool(binding, "command", false);
+
+    obs_data_array_push_back(defaults, binding);
+    obs_data_release(binding);
+
+    obs_hotkey_load(id, defaults);
+    obs_data_array_release(defaults);
+}
+
+/**
+ * @brief Return a human-readable representation of the first binding registered
+ *        for a hotkey (e.g. "Shift + Left").  Returns "None" when unbound.
+ */
+static QString format_binding(obs_hotkey_id id) {
+
+    obs_data_array_t *bindings = obs_hotkey_save(id);
+    const size_t      count    = obs_data_array_count(bindings);
+
+    if (count == 0) {
+        obs_data_array_release(bindings);
+        return "None";
+    }
+
+    obs_data_t *item = obs_data_array_item(bindings, 0);
+
+    QStringList parts;
+    if (obs_data_get_bool(item, "shift"))
+        parts << "Shift";
+    if (obs_data_get_bool(item, "control"))
+        parts << "Ctrl";
+    if (obs_data_get_bool(item, "alt"))
+        parts << "Alt";
+    if (obs_data_get_bool(item, "command"))
+        parts << "Cmd";
+
+    // Convert "OBS_KEY_LEFT" → a friendly label
+    QString key = QString::fromUtf8(obs_data_get_string(item, "key"));
+    if (key.startsWith("OBS_KEY_")) {
+        key = key.mid(8); // strip prefix
+    }
+
+    // Map common keys to nicer symbols / names
+    static const struct {
+        const char *from;
+        const char *to;
+    } key_map[] = {
+        {"LEFT", "←"},
+        {"RIGHT", "→"},
+        {"UP", "↑"},
+        {"DOWN", "↓"},
+        {nullptr, nullptr},
+    };
+    for (int i = 0; key_map[i].from; ++i) {
+        if (key == key_map[i].from) {
+            key = key_map[i].to;
+            break;
+        }
+    }
+
+    parts << key;
+
+    obs_data_release(item);
+    obs_data_array_release(bindings);
+
+    return parts.join(" + ");
+}
+
+// ----------------------------------------------------------------------------
+// Dialog
+// ----------------------------------------------------------------------------
+
+namespace {
+
+class AchievementTrackerDialog final : public QDialog {
+    public:
+    explicit AchievementTrackerDialog(QWidget *parent = nullptr) : QDialog(parent) {
+
+        setWindowTitle("Achievement Tracker");
+        setModal(false);
+        setMinimumWidth(460);
+
+        auto *rootLayout = new QVBoxLayout(this);
+
+        // ---- Hotkeys section ------------------------------------------------
+        auto *hotkeysLabel = new QLabel("<b>Navigation Hotkeys</b>", this);
+
+        auto *hotkeysHelp = new QLabel(this);
+        hotkeysHelp->setWordWrap(true);
+        hotkeysHelp->setText(
+            "Keyboard shortcuts for cycling through achievements. "
+            "To reconfigure, open OBS Settings \u2192 Hotkeys and search for \"Achievement Tracker\".");
+
+        auto *hotkeysForm = new QFormLayout();
+        hotkeysForm->setLabelAlignment(Qt::AlignLeft);
+        hotkeysForm->setVerticalSpacing(6);
+
+        m_prevBinding = new QLabel(this);
+        m_nextBinding = new QLabel(this);
+        m_prevBinding->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        m_nextBinding->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        hotkeysForm->addRow("Previous Achievement", m_prevBinding);
+        hotkeysForm->addRow("Next Achievement", m_nextBinding);
+
+        rootLayout->addWidget(hotkeysLabel);
+        rootLayout->addSpacing(4);
+        rootLayout->addWidget(hotkeysHelp);
+        rootLayout->addSpacing(6);
+        rootLayout->addLayout(hotkeysForm);
+
+        // ---- Separator -------------------------------------------------------
+        auto *separator = new QFrame(this);
+        separator->setFrameShape(QFrame::HLine);
+        separator->setFrameShadow(QFrame::Sunken);
+        rootLayout->addSpacing(8);
+        rootLayout->addWidget(separator);
+        rootLayout->addSpacing(8);
+
+        // ---- Timing section --------------------------------------------------
+        auto *timingLabel = new QLabel("<b>Display Timing</b>", this);
+
+        auto *timingHelp = new QLabel(this);
+        timingHelp->setWordWrap(true);
+        timingHelp->setText("How long each phase of the automatic achievement cycle is displayed.");
+
+        auto *timingForm = new QFormLayout();
+        timingForm->setLabelAlignment(Qt::AlignLeft);
+        timingForm->setVerticalSpacing(6);
+        timingForm->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
+
+        m_lastUnlockedSpin = new QSpinBox(this);
+        m_lastUnlockedSpin->setRange(ACHIEVEMENT_CYCLE_MIN_DURATION, 3600);
+        m_lastUnlockedSpin->setSuffix(" s");
+        m_lastUnlockedSpin->setToolTip("Seconds to display the most recently unlocked achievement.");
+
+        m_lockedEachSpin = new QSpinBox(this);
+        m_lockedEachSpin->setRange(ACHIEVEMENT_CYCLE_MIN_DURATION, 3600);
+        m_lockedEachSpin->setSuffix(" s");
+        m_lockedEachSpin->setToolTip("Seconds to display each random locked achievement during the rotation phase.");
+
+        m_lockedTotalSpin = new QSpinBox(this);
+        m_lockedTotalSpin->setRange(ACHIEVEMENT_CYCLE_MIN_DURATION, 3600);
+        m_lockedTotalSpin->setSuffix(" s");
+        m_lockedTotalSpin->setToolTip(
+            "Total seconds to spend in the locked rotation. Must be at least the per-locked duration "
+            "so that at least one locked achievement is shown per cycle.");
+
+        timingForm->addRow("Last unlocked", m_lastUnlockedSpin);
+        timingForm->addRow("Each locked", m_lockedEachSpin);
+        timingForm->addRow("Locked rotation total", m_lockedTotalSpin);
+
+        /* Keep the locked-total minimum in sync: it must always be >= each-locked so
+         * that the rotation phase can show at least one locked achievement. */
+        connect(m_lockedEachSpin, &QSpinBox::valueChanged, this, [this](int value) {
+            m_lockedTotalSpin->setMinimum(value);
+        });
+
+        rootLayout->addWidget(timingLabel);
+        rootLayout->addSpacing(4);
+        rootLayout->addWidget(timingHelp);
+        rootLayout->addSpacing(6);
+        rootLayout->addLayout(timingForm);
+
+        // ---- Buttons ---------------------------------------------------------
+        auto *buttonBox = new QDialogButtonBox(this);
+        m_saveButton    = buttonBox->addButton("Save", QDialogButtonBox::AcceptRole);
+        buttonBox->addButton(QDialogButtonBox::Close);
+
+        rootLayout->addSpacing(8);
+        rootLayout->addWidget(buttonBox);
+
+        connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::close);
+        connect(m_saveButton, &QPushButton::clicked, this, &AchievementTrackerDialog::onSave);
+
+        refreshBindings();
+        loadTimings();
+    }
+
+    void refreshBindings() {
+        m_prevBinding->setText(format_binding(g_hotkey_previous_id));
+        m_nextBinding->setText(format_binding(g_hotkey_next_id));
+    }
+
+    void loadTimings() {
+        achievement_cycle_timings_t *timings = state_get_achievement_cycle_timings();
+        if (!timings) {
+            return;
+        }
+
+        m_lastUnlockedSpin->setValue(timings->last_unlocked_duration);
+        m_lockedEachSpin->setValue(timings->locked_achievement_duration);
+        m_lockedTotalSpin->setValue(timings->locked_cycle_total_duration);
+
+        bfree(timings);
+    }
+
+    private:
+    void onSave() {
+        achievement_cycle_timings_t timings;
+        timings.last_unlocked_duration      = m_lastUnlockedSpin->value();
+        timings.locked_achievement_duration = m_lockedEachSpin->value();
+        timings.locked_cycle_total_duration = m_lockedTotalSpin->value();
+
+        state_set_achievement_cycle_timings(&timings);
+
+        achievement_cycle_set_timings((float)timings.last_unlocked_duration,
+                                      (float)timings.locked_achievement_duration,
+                                      (float)timings.locked_cycle_total_duration);
+
+        obs_log(LOG_INFO,
+                "Achievement Tracker: timings saved — last_unlocked=%ds, locked_each=%ds, locked_total=%ds",
+                timings.last_unlocked_duration,
+                timings.locked_achievement_duration,
+                timings.locked_cycle_total_duration);
+    }
+
+    QLabel      *m_prevBinding;
+    QLabel      *m_nextBinding;
+    QSpinBox    *m_lastUnlockedSpin;
+    QSpinBox    *m_lockedEachSpin;
+    QSpinBox    *m_lockedTotalSpin;
+    QPushButton *m_saveButton;
+};
+
+QPointer<AchievementTrackerDialog> g_dialog;
+
+void show_achievement_tracker_dialog(void *) {
+    auto *parent = static_cast<QWidget *>(obs_frontend_get_main_window());
+
+    if (!g_dialog) {
+        g_dialog = new AchievementTrackerDialog(parent);
+        g_dialog->setAttribute(Qt::WA_DeleteOnClose, true);
+    }
+
+    g_dialog->refreshBindings();
+    g_dialog->loadTimings();
+    g_dialog->show();
+    g_dialog->raise();
+    g_dialog->activateWindow();
+}
+
+} // namespace
+
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
+extern "C" void achievement_tracker_config_register(void) {
+
+    g_hotkey_previous_id = obs_hotkey_register_frontend("achievement_tracker.previous_achievement",
+                                                        "Achievement Tracker: Previous Achievement",
+                                                        on_previous_achievement,
+                                                        nullptr);
+
+    g_hotkey_next_id = obs_hotkey_register_frontend("achievement_tracker.next_achievement",
+                                                    "Achievement Tracker: Next Achievement",
+                                                    on_next_achievement,
+                                                    nullptr);
+
+    // Apply default bindings only when the user has not yet configured the hotkey.
+    load_default_binding(g_hotkey_previous_id, "OBS_KEY_LEFT", /*shift=*/true, /*ctrl=*/false, /*alt=*/false);
+    load_default_binding(g_hotkey_next_id, "OBS_KEY_RIGHT", /*shift=*/true, /*ctrl=*/false, /*alt=*/false);
+
+    obs_frontend_add_tools_menu_item("Achievement Tracker", show_achievement_tracker_dialog, nullptr);
+
+    obs_log(LOG_INFO,
+            "Achievement Tracker: hotkeys registered (previous=%llu, next=%llu)",
+            (unsigned long long)g_hotkey_previous_id,
+            (unsigned long long)g_hotkey_next_id);
+}
+
+extern "C" void achievement_tracker_config_unregister(void) {
+
+    if (g_dialog) {
+        g_dialog->close();
+        g_dialog->deleteLater();
+        g_dialog.clear();
+    }
+}

--- a/src/ui/achievement_tracker_config.h
+++ b/src/ui/achievement_tracker_config.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Register the Achievement Tracker configuration entry in the OBS Tools
+ *        menu and set up the navigation hotkeys.
+ *
+ * Registers two OBS frontend hotkeys:
+ *   - "Previous Achievement" (default: Shift+Left)
+ *   - "Next Achievement"     (default: Shift+Right)
+ *
+ * Adds an "Achievement Tracker" item to the OBS Tools menu where the user
+ * can see the current hotkey bindings.
+ */
+void achievement_tracker_config_register(void);
+
+/**
+ * @brief Tear down the Achievement Tracker configuration UI state.
+ */
+void achievement_tracker_config_unregister(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/stubs/integrations/retro_achievements_monitor_stub.c
+++ b/test/stubs/integrations/retro_achievements_monitor_stub.c
@@ -90,6 +90,11 @@ void mock_retro_monitor_fire_no_game(void) {
         s_cb_no_game();
 }
 
+void mock_retro_monitor_fire_achievements(const retro_achievement_t *achievements, size_t count) {
+    if (s_cb_achievements)
+        s_cb_achievements(achievements, count);
+}
+
 void mock_retro_monitor_reset(void) {
     s_cb_connection_changed = NULL;
     s_cb_user               = NULL;

--- a/test/stubs/integrations/retro_achievements_monitor_stub.h
+++ b/test/stubs/integrations/retro_achievements_monitor_stub.h
@@ -40,6 +40,14 @@ void mock_retro_monitor_fire_game_playing(const retro_game_t *game);
 void mock_retro_monitor_fire_no_game(void);
 
 /**
+ * @brief Simulate an "achievements" message arriving from the RetroArch server.
+ *
+ * @param achievements Pointer to an array of achievement records.
+ * @param count        Number of entries in @p achievements.
+ */
+void mock_retro_monitor_fire_achievements(const retro_achievement_t *achievements, size_t count);
+
+/**
  * @brief Reset all stub state. Call from tearDown().
  */
 void mock_retro_monitor_reset(void);

--- a/test/test_monitoring_service.c
+++ b/test/test_monitoring_service.c
@@ -33,6 +33,18 @@
  *  Race conditions:
  *  17. session_ready fires before game_played returns (all icons cached) →
  *      achievements must not be wiped by the late game_played callback
+ *
+ *  Achievement management — retro source:
+ *  18. Retro achievements arrive with game active → achievements stored, session_ready fired
+ *  19. Retro achievements arrive without a game → achievements stored, session_ready NOT fired
+ *  20. Retro disconnect with game active → achievements cleared
+ *
+ *  Achievement management — Xbox/retro coexistence (race condition fixes):
+ *  21. Xbox game stops while retro is active → retro achievements preserved
+ *  22. Xbox game stops while retro is active → game_played(NULL) NOT propagated to subscribers
+ *  23. Xbox session_ready fires without an Xbox game → achievements NOT overwritten
+ *  24. Xbox session_ready fires without an Xbox game → session_ready NOT re-fired
+ *  25. Xbox session_ready fires with an Xbox game active → session_ready fired normally
  */
 
 #include "unity.h"
@@ -87,8 +99,16 @@ static void fill_retro_game(retro_game_t *g, const char *id, const char *name) {
     strncpy(g->console_name, "SNES", sizeof(g->console_name) - 1);
 }
 
+static void fill_retro_achievement(retro_achievement_t *a, uint32_t id, const char *name, const char *status) {
+    memset(a, 0, sizeof(*a));
+    a->id     = id;
+    a->points = 10;
+    strncpy(a->name, name, sizeof(a->name) - 1);
+    strncpy(a->status, status, sizeof(a->status) - 1);
+}
+
 /* -------------------------------------------------------------------------
- * Subscriber spy
+ * Subscriber spies
  * ---------------------------------------------------------------------- */
 
 static int               s_identity_cb_count = 0;
@@ -99,19 +119,46 @@ static void on_identity_changed(const identity_t *identity) {
     s_last_identity = identity;
 }
 
+static int s_session_ready_cb_count = 0;
+
+static void on_session_ready(void) {
+    s_session_ready_cb_count++;
+}
+
+static int           s_game_played_cb_count = 0;
+static const game_t *s_last_game_played     = NULL;
+
+static void on_game_played(const game_t *game) {
+    s_game_played_cb_count++;
+    s_last_game_played = game;
+}
+
+static int s_achievements_changed_cb_count = 0;
+
+static void on_achievements_changed(void) {
+    s_achievements_changed_cb_count++;
+}
+
 /* -------------------------------------------------------------------------
  * setUp / tearDown
  * ---------------------------------------------------------------------- */
 
 void setUp(void) {
-    s_identity_cb_count = 0;
-    s_last_identity     = NULL;
+    s_identity_cb_count             = 0;
+    s_last_identity                 = NULL;
+    s_session_ready_cb_count        = 0;
+    s_game_played_cb_count          = 0;
+    s_last_game_played              = NULL;
+    s_achievements_changed_cb_count = 0;
 
     mock_xbox_monitor_reset();
     mock_retro_monitor_reset();
 
     monitoring_start();
     monitoring_subscribe_active_identity(on_identity_changed);
+    monitoring_subscribe_session_ready(on_session_ready);
+    monitoring_subscribe_game_played(on_game_played);
+    monitoring_subscribe_achievements_changed(on_achievements_changed);
 
     /* Consume the immediate callback fired by monitoring_subscribe_active_identity
      * (returns current identity, which is NULL at start). */
@@ -507,6 +554,170 @@ static void monitoring_achievements__session_ready_before_game_played__achieveme
     TEST_ASSERT_NULL(monitoring_get_current_game_achievements());
 }
 
+/* =========================================================================
+ * Achievement management — retro source
+ * ====================================================================== */
+
+/* 18. Retro achievements arrive while a game is active → achievements stored
+ *     and session_ready fired to subscribers. */
+static void monitoring_achievements__retro_achievements_with_game__achievements_stored_and_session_ready_fired(void) {
+    retro_game_t game;
+    fill_retro_game(&game, "crc-abc", "Chrono Trigger");
+    mock_retro_monitor_fire_connection_changed(true, NULL);
+    mock_retro_monitor_fire_game_playing(&game);
+
+    s_session_ready_cb_count        = 0;
+    s_achievements_changed_cb_count = 0;
+
+    retro_achievement_t achievements[2];
+    fill_retro_achievement(&achievements[0], 1, "First Win", "unlocked");
+    fill_retro_achievement(&achievements[1], 2, "Second Win", "locked");
+    mock_retro_monitor_fire_achievements(achievements, 2);
+
+    TEST_ASSERT_NOT_NULL(monitoring_get_current_game_achievements());
+    TEST_ASSERT_EQUAL_INT(1, s_achievements_changed_cb_count);
+    TEST_ASSERT_EQUAL_INT(1, s_session_ready_cb_count);
+}
+
+/* 19. Retro achievements arrive without a game context → achievements stored
+ *     (ready for future use) but session_ready must NOT fire. */
+static void monitoring_achievements__retro_achievements_without_game__stored_but_session_ready_not_fired(void) {
+    /* Connect but do NOT fire game_playing. */
+    mock_retro_monitor_fire_connection_changed(true, NULL);
+
+    s_session_ready_cb_count        = 0;
+    s_achievements_changed_cb_count = 0;
+
+    retro_achievement_t achievements[1];
+    fill_retro_achievement(&achievements[0], 1, "First Win", "locked");
+    mock_retro_monitor_fire_achievements(achievements, 1);
+
+    TEST_ASSERT_NOT_NULL(monitoring_get_current_game_achievements());
+    TEST_ASSERT_EQUAL_INT(1, s_achievements_changed_cb_count);
+    TEST_ASSERT_EQUAL_INT(0, s_session_ready_cb_count);
+}
+
+/* 20. Retro disconnects while a game is active → achievements must be cleared. */
+static void monitoring_achievements__retro_disconnected_with_game_active__achievements_cleared(void) {
+    retro_game_t game;
+    fill_retro_game(&game, "crc-abc", "Chrono Trigger");
+    mock_retro_monitor_fire_connection_changed(true, NULL);
+    mock_retro_monitor_fire_game_playing(&game);
+
+    retro_achievement_t achievements[1];
+    fill_retro_achievement(&achievements[0], 1, "First Win", "unlocked");
+    mock_retro_monitor_fire_achievements(achievements, 1);
+
+    TEST_ASSERT_NOT_NULL(monitoring_get_current_game_achievements());
+
+    mock_retro_monitor_fire_connection_changed(false, NULL);
+
+    TEST_ASSERT_NULL(monitoring_get_current_game_achievements());
+}
+
+/* =========================================================================
+ * Achievement management — Xbox / retro coexistence (race condition fixes)
+ * ====================================================================== */
+
+/* 21. Xbox fires game_stopped while a retro game is active → the retro
+ *     achievements must remain in place (not wiped by the Xbox callback). */
+static void monitoring_achievements__xbox_game_stopped_while_retro_active__retro_achievements_preserved(void) {
+    retro_game_t retro_game;
+    fill_retro_game(&retro_game, "crc-abc", "Chrono Trigger");
+    mock_retro_monitor_fire_connection_changed(true, NULL);
+    mock_retro_monitor_fire_game_playing(&retro_game);
+
+    retro_achievement_t achievements[1];
+    fill_retro_achievement(&achievements[0], 1, "First Win", "unlocked");
+    mock_retro_monitor_fire_achievements(achievements, 1);
+
+    TEST_ASSERT_NOT_NULL(monitoring_get_current_game_achievements());
+
+    /* Xbox game stops — retro session must remain intact. */
+    mock_xbox_monitor_fire_game_played(NULL);
+
+    TEST_ASSERT_NOT_NULL(monitoring_get_current_game_achievements());
+}
+
+/* 22. Xbox fires game_stopped while a retro game is active → game_played(NULL)
+ *     must NOT be propagated to subscribers, so the display cycle is not reset. */
+static void monitoring_game_played__xbox_game_stopped_while_retro_active__null_not_propagated(void) {
+    retro_game_t retro_game;
+    fill_retro_game(&retro_game, "crc-abc", "Chrono Trigger");
+    mock_retro_monitor_fire_connection_changed(true, NULL);
+    mock_retro_monitor_fire_game_playing(&retro_game);
+
+    /* Reset after game_playing (which legitimately fires game_played once). */
+    s_game_played_cb_count = 0;
+    s_last_game_played     = NULL;
+
+    /* Xbox game stops — must not touch the retro session. */
+    mock_xbox_monitor_fire_game_played(NULL);
+
+    TEST_ASSERT_EQUAL_INT(0, s_game_played_cb_count);
+}
+
+/* 23. Xbox fires session_ready when it has no active game → the current
+ *     achievements (owned by a running retro session) must not be overwritten. */
+static void monitoring_achievements__xbox_session_ready_without_game__achievements_not_overwritten(void) {
+    retro_game_t retro_game;
+    fill_retro_game(&retro_game, "crc-abc", "Chrono Trigger");
+    mock_retro_monitor_fire_connection_changed(true, NULL);
+    mock_retro_monitor_fire_game_playing(&retro_game);
+
+    retro_achievement_t achievements[1];
+    fill_retro_achievement(&achievements[0], 1, "First Win", "unlocked");
+    mock_retro_monitor_fire_achievements(achievements, 1);
+
+    TEST_ASSERT_NOT_NULL(monitoring_get_current_game_achievements());
+
+    s_achievements_changed_cb_count = 0;
+
+    /* Xbox fires session_ready without an active game — must be a no-op. */
+    mock_xbox_monitor_fire_session_ready();
+
+    TEST_ASSERT_NOT_NULL(monitoring_get_current_game_achievements());
+    TEST_ASSERT_EQUAL_INT(0, s_achievements_changed_cb_count);
+}
+
+/* 24. Xbox fires session_ready when it has no active game → session_ready must
+ *     NOT be re-fired to subscribers (that would restart the display cycle). */
+static void monitoring_session_ready__xbox_session_ready_without_game__not_fired(void) {
+    retro_game_t retro_game;
+    fill_retro_game(&retro_game, "crc-abc", "Chrono Trigger");
+    mock_retro_monitor_fire_connection_changed(true, NULL);
+    mock_retro_monitor_fire_game_playing(&retro_game);
+
+    retro_achievement_t achievements[1];
+    fill_retro_achievement(&achievements[0], 1, "First Win", "unlocked");
+    mock_retro_monitor_fire_achievements(achievements, 1);
+
+    /* Reset after the retro session_ready that legitimately fired above. */
+    s_session_ready_cb_count = 0;
+
+    /* Xbox fires session_ready without a game — must be ignored. */
+    mock_xbox_monitor_fire_session_ready();
+
+    TEST_ASSERT_EQUAL_INT(0, s_session_ready_cb_count);
+}
+
+/* 25. Xbox fires session_ready with an active Xbox game → session_ready fires
+ *     normally (positive path; regression guard). */
+static void monitoring_session_ready__xbox_session_ready_with_game__fired(void) {
+    mock_xbox_monitor_set_identity(make_xbox_identity("MasterChief"));
+    mock_xbox_monitor_fire_connection_changed(true, NULL);
+
+    game_t *xbox_game = make_xbox_game("game-1", "Halo Infinite");
+    mock_xbox_monitor_fire_game_played(xbox_game);
+    free_game(&xbox_game);
+
+    s_session_ready_cb_count = 0;
+
+    mock_xbox_monitor_fire_session_ready();
+
+    TEST_ASSERT_EQUAL_INT(1, s_session_ready_cb_count);
+}
+
 /* -------------------------------------------------------------------------
  * Test runner
  * ---------------------------------------------------------------------- */
@@ -538,6 +749,18 @@ int main(void) {
 
     /* Race conditions */
     RUN_TEST(monitoring_achievements__session_ready_before_game_played__achievements_not_wiped);
+
+    /* Achievement management — retro source */
+    RUN_TEST(monitoring_achievements__retro_achievements_with_game__achievements_stored_and_session_ready_fired);
+    RUN_TEST(monitoring_achievements__retro_achievements_without_game__stored_but_session_ready_not_fired);
+    RUN_TEST(monitoring_achievements__retro_disconnected_with_game_active__achievements_cleared);
+
+    /* Achievement management — Xbox/retro coexistence (race condition fixes) */
+    RUN_TEST(monitoring_achievements__xbox_game_stopped_while_retro_active__retro_achievements_preserved);
+    RUN_TEST(monitoring_game_played__xbox_game_stopped_while_retro_active__null_not_propagated);
+    RUN_TEST(monitoring_achievements__xbox_session_ready_without_game__achievements_not_overwritten);
+    RUN_TEST(monitoring_session_ready__xbox_session_ready_without_game__not_fired);
+    RUN_TEST(monitoring_session_ready__xbox_session_ready_with_game__fired);
 
     return UNITY_END();
 }


### PR DESCRIPTION
This pull request adds support for tracking and displaying "measured progress" (such as "5/10") for achievements, improves the handling of achievement unlock timestamps, and refines the achievement display cycle to ensure the UI is never blank at session start. It also enhances session and achievement state management to avoid race conditions and stale data.

**Achievement structure and progress tracking:**

* Added a `measured_progress` field to `achievement_t` and `retro_achievement_t` structs, along with support for copying, freeing, and parsing this field from JSON messages. This allows achievements with partial progress to display their current state (e.g., "5/10"). [[1]](diffhunk://#diff-479e99948d163b663f3c9b40bbc833345aa9a0df460ad99ef2c8ef92be55de89R61-R66) [[2]](diffhunk://#diff-8cbe6aeec6523f3b3e102b031084eec53dd6bdbdb1f69705cddf46cc0f5519b2L82-R89) [[3]](diffhunk://#diff-7a5c508b70cee5bbfb4db6076596fe797bcca0b65a9a7fd73a8c4e4d09fd4653R29) [[4]](diffhunk://#diff-7a5c508b70cee5bbfb4db6076596fe797bcca0b65a9a7fd73a8c4e4d09fd4653R65) [[5]](diffhunk://#diff-3c5f10586c7445a1aa8d4a445e1455312d197ba3d9881a3a965043ab0d5d4ab5R335-R342) [[6]](diffhunk://#diff-8cbe6aeec6523f3b3e102b031084eec53dd6bdbdb1f69705cddf46cc0f5519b2R29-R30) [[7]](diffhunk://#diff-bb799e4e894f786f13d6533800368c91d82a1d770c963861694076d4bb33e4feR210-R222)

* Updated the JSON protocol and documentation to include `measured_progress` and `unlock_time` for achievements. [[1]](diffhunk://#diff-8cbe6aeec6523f3b3e102b031084eec53dd6bdbdb1f69705cddf46cc0f5519b2R29-R30) [[2]](diffhunk://#diff-8cbe6aeec6523f3b3e102b031084eec53dd6bdbdb1f69705cddf46cc0f5519b2L82-R89)

**Achievement unlock timestamp improvements:**

* Improved handling of achievement unlock timestamps by using the real `unlock_time` when available, or a sentinel value when not, ensuring accurate and consistent unlock tracking. [[1]](diffhunk://#diff-bb799e4e894f786f13d6533800368c91d82a1d770c963861694076d4bb33e4feR210-R222) [[2]](diffhunk://#diff-3c5f10586c7445a1aa8d4a445e1455312d197ba3d9881a3a965043ab0d5d4ab5R335-R342)

**Achievement display cycle and UI experience:**

* Enhanced the achievement display cycle so that if there are no unlocked achievements, a random locked achievement is shown immediately, preventing the display from being blank at session start. [[1]](diffhunk://#diff-4b52cfce031462f191aa59d4d65b93ca4c72f281a48d6771e2bd00852da4733bL87-R96) [[2]](diffhunk://#diff-4b52cfce031462f191aa59d4d65b93ca4c72f281a48d6771e2bd00852da4733bL110-R145)

* Ensured proper freeing of the last unlocked achievement when the game changes, preventing memory leaks and dangling pointers.

**Session and achievement state management:**

* Refined the order of notifications and state changes when games or connections change, preventing race conditions where UI could be blanked out or left in a stale state. This includes firing `notify_game_played` and `notify_active_identity` before clearing achievements, and only firing `notify_session_ready` when a game is active. [[1]](diffhunk://#diff-bb799e4e894f786f13d6533800368c91d82a1d770c963861694076d4bb33e4feL354-R385) [[2]](diffhunk://#diff-bb799e4e894f786f13d6533800368c91d82a1d770c963861694076d4bb33e4feL398-R472)