### PR TITLE
[PL-81] - Support for achievement progress

### DIFF
--- a/.github/actions/build-plugin/action.yaml
+++ b/.github/actions/build-plugin/action.yaml
@@ -53,7 +53,6 @@ runs:
       shell: zsh --no-rcs --errexit --pipefail {0}
       working-directory: ${{ inputs.workingDirectory }}
       env:
-        CCACHE_DIR: ${{ inputs.workingDirectory }}/.ccache
         CODESIGN_IDENT: ${{ inputs.codesignIdent }}
         CODESIGN_TEAM: ${{ inputs.codesignTeam }}
       run: |
@@ -129,7 +128,7 @@ runs:
         .github/scripts/Build-Windows.ps1 @BuildArgs
 
     - name: Create Summary 📊
-      if: contains(fromJSON('["Linux", "macOS"]'),runner.os)
+      if: runner.os == 'Linux'
       shell: zsh --no-rcs --errexit --pipefail {0}
       env:
         CCACHE_DIR: ${{ inputs.workingDirectory }}/.ccache

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -203,14 +203,6 @@ jobs:
           if (( #remove_formulas )) brew uninstall --ignore-dependencies ${remove_formulas}
           print '::endgroup::'
 
-      - uses: actions/cache/restore@v4
-        id: ccache-cache
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-ccache-${{ needs.check-event.outputs.config }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-
-
       - name: Set Up Codesigning 🔑
         uses: ./.github/actions/setup-macos-codesigning
         if: fromJSON(needs.check-event.outputs.codesign)
@@ -299,12 +291,6 @@ jobs:
         with:
           name: ${{ needs.check-event.outputs.pluginInternalName }}-${{ needs.check-event.outputs.pluginVersion }}-macos-universal-${{ needs.check-event.outputs.commitHash }}-dSYMs
           path: ${{ github.workspace }}/release/${{ needs.check-event.outputs.pluginInternalName }}-${{ needs.check-event.outputs.pluginVersion }}-macos-universal-dSYMs.*
-
-      - uses: actions/cache/save@v4
-        if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-ccache-${{ needs.check-event.outputs.config }}
 
   ubuntu-build:
     name: Build for Ubuntu x86_64 🐧

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,6 +744,7 @@ if(BUILD_TESTING)
     src/integrations/xbox/contracts/xbox_achievement_progress.c
     src/integrations/xbox/contracts/xbox_unlocked_achievement.c
     src/integrations/xbox/entities/xbox_identity.c
+    src/sources/common/achievement_cycle.c
     test/stubs/bmem_stub.c
     test/stubs/integrations/xbox_monitor_stub.c
     test/stubs/integrations/retro_achievements_monitor_stub.c

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,8 +43,8 @@
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "ENABLE_CCACHE": true
-      }
+        "ENABLE_CCACHE": false
+    }
     },
     {
       "name": "macos-dev",

--- a/src/integrations/monitoring_service.c
+++ b/src/integrations/monitoring_service.c
@@ -12,6 +12,8 @@
 #include "common/gamerscore.h"
 #include "common/memory.h"
 #include "io/state.h"
+#include "sources/common/achievement_cycle.h"
+#include "time/time.h"
 
 /* --------------------------------------------------------------------------
  * Active-identity subscription list
@@ -291,7 +293,6 @@ static void on_xbox_connection_changed(bool connected, const char *error_message
 static void on_xbox_achievements_progressed(const gamerscore_t                *gamerscore,
                                             const xbox_achievement_progress_t *progress) {
     UNUSED_PARAMETER(gamerscore);
-    UNUSED_PARAMETER(progress);
 
     if (!g_xbox_identity)
         return;
@@ -299,8 +300,39 @@ static void on_xbox_achievements_progressed(const gamerscore_t                *g
     refresh_xbox_score(g_xbox_identity);
     obs_log(LOG_INFO, "[MonitoringService] Xbox score updated: %u", g_xbox_identity->score);
 
-    /* Refresh the cached generic achievements. */
-    replace_current_achievements(xbox_to_achievements(get_current_game_achievements()));
+    /* Update the measured_progress field in-place on the cached generic
+     * achievement so the display reflects the new value without resetting
+     * the cycle (which would jump back to the first achievement). */
+    if (progress && progress->id && g_current_achievements) {
+        for (achievement_t *a = g_current_achievements; a != NULL; a = a->next) {
+            if (a->id && strcasecmp(a->id, progress->id) == 0) {
+
+                if (progress->progress_state && strcasecmp(progress->progress_state, "Achieved") == 0) {
+                    /* Achievement was just unlocked — patch in-place using the
+                     * timestamp already present in the progress event, clear the
+                     * progress string, then re-sort so it moves to the unlocked
+                     * section of the cycle.  No rebuild needed: we have all the
+                     * information we need right here. */
+                    a->unlocked_timestamp = progress->unlocked_timestamp > 0 ? progress->unlocked_timestamp
+                                                                             : (int64_t)now();
+                    free_memory((void **)&a->measured_progress);
+                    sort_achievements(&g_current_achievements);
+                    notify_achievements_changed();
+                } else {
+                    /* Still in progress — patch measured_progress in-place so
+                     * the display updates without resetting the cycle. */
+                    free_memory((void **)&a->measured_progress);
+                    if (progress->current && progress->target && strcmp(progress->current, "0") != 0) {
+                        char measured[128];
+                        snprintf(measured, sizeof(measured), "%s/%s", progress->current, progress->target);
+                        a->measured_progress = bstrdup(measured);
+                    }
+                    achievement_cycle_refresh_current();
+                }
+                break;
+            }
+        }
+    }
 
     /* Re-notify so subscribers receive the updated score. */
     if (g_xbox_game)
@@ -471,11 +503,19 @@ static void on_retro_no_game(void) {
  * event (initial state dump on connection). Treating that as session-ready
  * would set g_session_ready = true with no game context, which could then
  * block the next real game's session from starting correctly.
+ *
+ * Similarly, RetroArch may send an empty achievements list immediately after
+ * game_playing (count=0) as a loading placeholder before the real list
+ * arrives. Treating that as session-ready would start the cycle with no
+ * achievements and leave it blank until on_achievements_changed fires again —
+ * which only resets the display when g_session_ready is already true, so the
+ * initial blank state persists. Only fire session_ready when the list is
+ * non-empty so the cycle always starts with at least one achievement to show.
  */
 static void on_retro_achievements(const retro_achievement_t *achievements, size_t count) {
     replace_current_achievements(retro_to_achievements(achievements, count));
 
-    if (g_retro_game) {
+    if (g_retro_game && count > 0) {
         notify_session_ready();
     }
 }

--- a/src/integrations/xbox/contracts/xbox_achievement.c
+++ b/src/integrations/xbox/contracts/xbox_achievement.c
@@ -337,7 +337,7 @@ achievement_t *xbox_to_achievements(const xbox_achievement_t *xbox) {
         a->unlocked_timestamp = x->unlocked_timestamp;
         a->source             = ACHIEVEMENT_SOURCE_XBOX;
 
-        if (x->progression_current && x->progression_target) {
+        if (x->progression_current && x->progression_target && strcmp(x->progression_current, "0") != 0) {
             char measured[128];
             snprintf(measured, sizeof(measured), "%s/%s", x->progression_current, x->progression_target);
             a->measured_progress = bstrdup(measured);

--- a/src/integrations/xbox/contracts/xbox_achievement.c
+++ b/src/integrations/xbox/contracts/xbox_achievement.c
@@ -4,6 +4,7 @@
 
 #include <inttypes.h>
 #include <obs-module.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 xbox_media_asset_t *xbox_copy_media_asset(const xbox_media_asset_t *media_asset) {
@@ -125,17 +126,19 @@ xbox_achievement_t *xbox_copy_achievement(const xbox_achievement_t *achievement)
 
         xbox_achievement_t *copy = bzalloc(sizeof(xbox_achievement_t));
 
-        copy->id                 = bstrdup(current->id);
-        copy->description        = bstrdup(current->description);
-        copy->locked_description = bstrdup(current->locked_description);
-        copy->name               = bstrdup(current->name);
-        copy->progress_state     = bstrdup(current->progress_state);
-        copy->service_config_id  = bstrdup(current->service_config_id);
-        copy->icon_url           = bstrdup(current->icon_url);
-        copy->media_assets       = xbox_copy_media_asset(current->media_assets);
-        copy->rewards            = xbox_copy_reward(current->rewards);
-        copy->is_secret          = current->is_secret;
-        copy->unlocked_timestamp = current->unlocked_timestamp;
+        copy->id                  = bstrdup(current->id);
+        copy->description         = bstrdup(current->description);
+        copy->locked_description  = bstrdup(current->locked_description);
+        copy->name                = bstrdup(current->name);
+        copy->progress_state      = bstrdup(current->progress_state);
+        copy->service_config_id   = bstrdup(current->service_config_id);
+        copy->icon_url            = bstrdup(current->icon_url);
+        copy->media_assets        = xbox_copy_media_asset(current->media_assets);
+        copy->rewards             = xbox_copy_reward(current->rewards);
+        copy->is_secret           = current->is_secret;
+        copy->unlocked_timestamp  = current->unlocked_timestamp;
+        copy->progression_current = bstrdup(current->progression_current);
+        copy->progression_target  = bstrdup(current->progression_target);
 
         if (previous_copy) {
             previous_copy->next = copy;
@@ -170,6 +173,8 @@ void xbox_free_achievement(xbox_achievement_t **achievement) {
         free_memory((void **)&current->locked_description);
         free_memory((void **)&current->progress_state);
         free_memory((void **)&current->icon_url);
+        free_memory((void **)&current->progression_current);
+        free_memory((void **)&current->progression_target);
         xbox_free_media_asset(&current->media_assets);
         xbox_free_reward(&current->rewards);
         free_memory((void **)&current);
@@ -331,6 +336,12 @@ achievement_t *xbox_to_achievements(const xbox_achievement_t *xbox) {
         a->value              = (x->rewards && x->rewards->value) ? atoi(x->rewards->value) : 0;
         a->unlocked_timestamp = x->unlocked_timestamp;
         a->source             = ACHIEVEMENT_SOURCE_XBOX;
+
+        if (x->progression_current && x->progression_target) {
+            char measured[128];
+            snprintf(measured, sizeof(measured), "%s/%s", x->progression_current, x->progression_target);
+            a->measured_progress = bstrdup(measured);
+        }
 
         if (previous) {
             previous->next = a;

--- a/src/integrations/xbox/contracts/xbox_achievement.h
+++ b/src/integrations/xbox/contracts/xbox_achievement.h
@@ -75,6 +75,16 @@ typedef struct xbox_achievement {
     /** Unix timestamp (seconds since epoch) when the achievement was unlocked, or 0 if locked. */
     int64_t                  unlocked_timestamp;
     /**
+     * Current progression value for the first requirement, as a service-provided string (e.g. "42").
+     * NULL if not available.
+     */
+    char                    *progression_current;
+    /**
+     * Target progression value for the first requirement, as a service-provided string (e.g. "100").
+     * NULL if not available.
+     */
+    char                    *progression_target;
+    /**
      * Small icon or tile image URL for the achievement.
      *
      * Typically points to a PNG/JPEG hosted by the service.

--- a/src/integrations/xbox/contracts/xbox_achievement_progress.c
+++ b/src/integrations/xbox/contracts/xbox_achievement_progress.c
@@ -21,6 +21,8 @@ xbox_achievement_progress_t *xbox_copy_achievement_progress(const xbox_achieveme
         copy->progress_state              = bstrdup(current->progress_state);
         copy->service_config_id           = bstrdup(current->service_config_id);
         copy->unlocked_timestamp          = current->unlocked_timestamp;
+        copy->current                     = bstrdup(current->current);
+        copy->target                      = bstrdup(current->target);
 
         if (previous_copy) {
             previous_copy->next = copy;
@@ -51,6 +53,8 @@ void xbox_free_achievement_progress(xbox_achievement_progress_t **achievement_pr
         free_memory((void **)&current->id);
         free_memory((void **)&current->progress_state);
         free_memory((void **)&current->service_config_id);
+        free_memory((void **)&current->current);
+        free_memory((void **)&current->target);
         free_memory((void **)&current);
 
         current = next;

--- a/src/integrations/xbox/contracts/xbox_achievement_progress.h
+++ b/src/integrations/xbox/contracts/xbox_achievement_progress.h
@@ -27,6 +27,16 @@ typedef struct xbox_achievement_progress {
     const char                       *progress_state;
     /** Unix timestamp (seconds since epoch) when the achievement was unlocked, or 0 if locked. */
     int64_t                           unlocked_timestamp;
+    /**
+     * Current progression value for the first requirement, as a service-provided string (e.g. "42").
+     * NULL if not available.
+     */
+    const char                       *current;
+    /**
+     * Target progression value for the first requirement, as a service-provided string (e.g. "100").
+     * NULL if not available.
+     */
+    const char                       *target;
     /** Next progress entry in the list, or NULL. */
     struct xbox_achievement_progress *next;
 } xbox_achievement_progress_t;

--- a/src/integrations/xbox/xbox_monitor.c
+++ b/src/integrations/xbox/xbox_monitor.c
@@ -225,7 +225,7 @@ static void notify_game_played(const game_t *game) {
 }
 
 /**
- * @brief Invoke all registered achievement progressed subscribers.
+ * @brief Invoke all registered achievement-progressed subscribers.
  */
 static void notify_achievements_progressed(const xbox_achievement_progress_t *achievements_progress) {
 
@@ -519,9 +519,16 @@ static void on_achievement_progress_received(const xbox_achievement_progress_t *
         return;
     }
 
-    /* TODO Progress is not necessarily achieved */
+    obs_log(LOG_INFO,
+            "[XboxMonitor] Progress received for achievement ID %s (%s)",
+            progress->id,
+            progress->progress_state);
 
-    xbox_session_unlock_achievement(&g_current_session, progress);
+    if (strcasecmp(progress->progress_state, "Achieved") == 0) {
+        xbox_session_unlock_achievement(&g_current_session, progress);
+    } else if (strcasecmp(progress->progress_state, "InProgress") == 0) {
+        xbox_session_progress_achievement(&g_current_session, progress);
+    }
 
     notify_achievements_progressed(progress);
 }

--- a/src/integrations/xbox/xbox_session.c
+++ b/src/integrations/xbox/xbox_session.c
@@ -252,6 +252,34 @@ void xbox_session_unlock_achievement(xbox_session_t *session, const xbox_achieve
             xbox_session_compute_gamerscore(session));
 }
 
+void xbox_session_progress_achievement(xbox_session_t *session, const xbox_achievement_progress_t *progress) {
+
+    if (!session || !progress) {
+        return;
+    }
+
+    xbox_achievement_t *achievement = find_achievement_by_id(progress, session->achievements);
+
+    if (!achievement) {
+        obs_log(LOG_ERROR,
+                "[XboxSession] Failed to progress achievement %s: not found in the game's achievements",
+                progress->id ? progress->id : "(null)");
+        return;
+    }
+
+    /* Updates the achievement status */
+    free_memory((void **)&achievement->progress_state);
+    achievement->progress_state = bstrdup(progress->progress_state);
+
+    free_memory((void **)&achievement->progression_current);
+    achievement->progression_current = bstrdup(progress->current);
+
+    obs_log(LOG_INFO,
+            "[XboxSession] Achievement '%s' progressed to %s",
+            achievement->name,
+            achievement->progression_current);
+}
+
 void xbox_session_clear(xbox_session_t *session) {
 
     if (!session) {

--- a/src/integrations/xbox/xbox_session.c
+++ b/src/integrations/xbox/xbox_session.c
@@ -11,6 +11,7 @@
 #include "integrations/xbox/contracts/xbox_unlocked_achievement.h"
 
 #include <errno.h>
+#include <time.h>
 #include <util/thread_compat.h>
 #include <stdlib.h>
 #include <string.h>
@@ -194,8 +195,15 @@ void xbox_session_unlock_achievement(xbox_session_t *session, const xbox_achieve
 
     /* Updates the achievement status */
     free_memory((void **)&achievement->progress_state);
-    achievement->progress_state     = bstrdup(progress->progress_state);
-    achievement->unlocked_timestamp = progress->unlocked_timestamp;
+    achievement->progress_state = bstrdup(progress->progress_state);
+
+    /* Xbox sends "0001-01-01T00:00:00" (parsed as 0) as the null unlock date.
+     * Fall back to the current time so the achievement is never treated as locked. */
+    achievement->unlocked_timestamp = (progress->unlocked_timestamp > 0) ? progress->unlocked_timestamp
+                                                                         : (int64_t)time(NULL);
+
+    /* Clear in-progress tracking — the achievement is now complete. */
+    free_memory((void **)&achievement->progression_current);
 
     xbox_sort_achievements(&session->achievements);
 

--- a/src/integrations/xbox/xbox_session.h
+++ b/src/integrations/xbox/xbox_session.h
@@ -73,6 +73,8 @@ void xbox_session_change_game(xbox_session_t *session, game_t *game, xbox_sessio
  */
 void xbox_session_unlock_achievement(xbox_session_t *session, const xbox_achievement_progress_t *progress);
 
+void xbox_session_progress_achievement(xbox_session_t *session, const xbox_achievement_progress_t *progress);
+
 /**
  * @brief Clears all session state.
  *

--- a/src/sources/achievement_name.c
+++ b/src/sources/achievement_name.c
@@ -142,8 +142,21 @@ static void update_achievement_name(const achievement_t *achievement) {
         g_must_reload = true;
     }
 
-    if (achievement->value > 0) {
+    if (achievement->value > 0 && achievement->measured_progress) {
+        snprintf(g_achievement_name,
+                 sizeof(g_achievement_name),
+                 "%d - %s (%s)",
+                 achievement->value,
+                 achievement->name,
+                 achievement->measured_progress);
+    } else if (achievement->value > 0) {
         snprintf(g_achievement_name, sizeof(g_achievement_name), "%d - %s", achievement->value, achievement->name);
+    } else if (achievement->measured_progress) {
+        snprintf(g_achievement_name,
+                 sizeof(g_achievement_name),
+                 "%s (%s)",
+                 achievement->name,
+                 achievement->measured_progress);
     } else {
         snprintf(g_achievement_name, sizeof(g_achievement_name), "%s", achievement->name);
     }

--- a/src/sources/common/achievement_cycle.c
+++ b/src/sources/common/achievement_cycle.c
@@ -572,6 +572,23 @@ bool achievement_cycle_is_auto_cycle_enabled(void) {
     return g_auto_cycle_enabled;
 }
 
+void achievement_cycle_refresh_current(void) {
+
+    if (!g_session_ready || !g_current_achievement) {
+        return;
+    }
+
+    /* Find the matching entry in the live list and re-notify subscribers so
+     * they pick up any in-place field changes (e.g. measured_progress). */
+    const achievement_t *live = monitoring_get_current_game_achievements();
+    for (const achievement_t *a = live; a != NULL; a = a->next) {
+        if (a->id && g_current_achievement->id && strcmp(a->id, g_current_achievement->id) == 0) {
+            notify_subscribers(a);
+            return;
+        }
+    }
+}
+
 void achievement_cycle_set_timings(float last_unlocked_secs, float locked_each_secs, float locked_total_secs) {
 
     g_last_unlocked_duration = last_unlocked_secs >= ACHIEVEMENT_CYCLE_MIN_DURATION ? last_unlocked_secs

--- a/src/sources/common/achievement_cycle.h
+++ b/src/sources/common/achievement_cycle.h
@@ -176,6 +176,17 @@ void achievement_cycle_set_auto_cycle(bool enabled);
  */
 bool achievement_cycle_is_auto_cycle_enabled(void);
 
+/**
+ * @brief Re-notify subscribers with the currently displayed achievement.
+ *
+ * Use this after an in-place field update (e.g. measured_progress) on the
+ * cached achievements list, when the cycle should not be reset but the
+ * display needs to reflect the new value.
+ *
+ * No-op if the session is not ready or no achievement is currently displayed.
+ */
+void achievement_cycle_refresh_current(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sources/common/text_source.c
+++ b/src/sources/common/text_source.c
@@ -320,6 +320,11 @@ bool text_source_update_text(text_source_t *text_source, bool *force_reload, con
     } else if (text_source->current_text && strcmp(text_source->current_text, text) != 0) {
         initiate_fade_out_transition(text_source, text, use_active_color);
         goto completed;
+    } else {
+        /* Text is unchanged — still propagate the active-color flag so that a
+         * state change (e.g. a progressed achievement being unlocked) is
+         * reflected even when the display text itself stays the same. */
+        text_source->use_active_color = use_active_color;
     }
 
     //  Update the private OBS source settings.

--- a/src/text/parsers.c
+++ b/src/text/parsers.c
@@ -343,6 +343,11 @@ xbox_achievement_t *parse_achievements(const char *json_string) {
         achievement->is_secret          = get_node_bool(json_root, achievement_index, "isSecret");
         achievement->unlocked_timestamp =
             get_node_unix_timestamp(json_root, achievement_index, "progression/timeUnlocked");
+        achievement->progression_current =
+            get_node_string(json_root, achievement_index, "progression/requirements/0/current");
+        achievement->progression_target =
+            get_node_string(json_root, achievement_index, "progression/requirements/0/target");
+
         char *icon_url        = get_node_string(json_root, achievement_index, "mediaAssets/0/url");
         achievement->icon_url = append_icon_size_query(icon_url);
         free_memory((void **)&icon_url);

--- a/src/text/parsers.c
+++ b/src/text/parsers.c
@@ -276,20 +276,29 @@ xbox_achievement_progress_t *parse_achievement_progress(const char *json_string)
             continue;
         }
 
-        int32_t fraction           = 0;
-        int64_t unlocked_timestamp = 0;
-
-        if (!convert_iso8601_utc_to_unix(time_unlocked_node->valuestring, &unlocked_timestamp, &fraction)) {
-            obs_log(LOG_ERROR, "No time unlocked at %d (received %s)", detail_index, time_unlocked_node->valuestring);
-            continue;
-        }
-
         xbox_achievement_progress_t *progress = bzalloc(sizeof(xbox_achievement_progress_t));
         progress->service_config_id           = bstrdup(current_service_config_id);
         progress->id                          = bstrdup(id_node->valuestring);
         progress->progress_state              = bstrdup(progress_state_node->valuestring);
-        progress->unlocked_timestamp          = unlocked_timestamp;
-        progress->next                        = NULL;
+
+        int32_t fraction           = 0;
+        int64_t unlocked_timestamp = 0;
+
+        if (convert_iso8601_utc_to_unix(time_unlocked_node->valuestring, &unlocked_timestamp, &fraction)) {
+            progress->unlocked_timestamp = unlocked_timestamp;
+        }
+
+        char current_key[512] = "";
+        snprintf(current_key, sizeof(current_key), "/progression/%d/requirements/0/current", detail_index);
+        cJSON *current_node = cJSONUtils_GetPointer(json_root, current_key);
+        progress->current   = (current_node && current_node->valuestring) ? bstrdup(current_node->valuestring) : NULL;
+
+        char target_key[512] = "";
+        snprintf(target_key, sizeof(target_key), "/progression/%d/requirements/0/target", detail_index);
+        cJSON *target_node = cJSONUtils_GetPointer(json_root, target_key);
+        progress->target   = (target_node && target_node->valuestring) ? bstrdup(target_node->valuestring) : NULL;
+
+        progress->next = NULL;
 
         if (!achievement_progress) {
             achievement_progress = progress;

--- a/test/stubs/integrations/xbox_monitor_stub.c
+++ b/test/stubs/integrations/xbox_monitor_stub.c
@@ -31,7 +31,7 @@ static on_xbox_achievements_progressed_t s_cb_achievements_progressed = NULL;
 static on_xbox_session_ready_t           s_cb_session_ready           = NULL;
 
 /* Identity returned by state_get_xbox_identity() */
-static xbox_identity_t  *s_xbox_identity     = NULL;
+static xbox_identity_t    *s_xbox_identity     = NULL;
 /* Achievements returned by get_current_game_achievements() */
 static xbox_achievement_t *s_xbox_achievements = NULL;
 
@@ -153,7 +153,7 @@ void mock_xbox_monitor_fire_session_ready(void) {
 }
 
 void mock_xbox_monitor_fire_achievements_progressed(const gamerscore_t                *gamerscore,
-                                                     const xbox_achievement_progress_t *progress) {
+                                                    const xbox_achievement_progress_t *progress) {
     if (s_cb_achievements_progressed)
         s_cb_achievements_progressed(gamerscore, progress);
 }

--- a/test/stubs/integrations/xbox_monitor_stub.c
+++ b/test/stubs/integrations/xbox_monitor_stub.c
@@ -13,6 +13,7 @@
 #include "integrations/xbox/xbox_monitor.h"
 #include "integrations/xbox/xbox_client.h"
 #include "integrations/xbox/entities/xbox_identity.h"
+#include "integrations/xbox/contracts/xbox_achievement.h"
 #include "io/state.h"
 #include "common/game.h"
 #include "common/gamerscore.h"
@@ -30,7 +31,9 @@ static on_xbox_achievements_progressed_t s_cb_achievements_progressed = NULL;
 static on_xbox_session_ready_t           s_cb_session_ready           = NULL;
 
 /* Identity returned by state_get_xbox_identity() */
-static xbox_identity_t *s_xbox_identity = NULL;
+static xbox_identity_t  *s_xbox_identity     = NULL;
+/* Achievements returned by get_current_game_achievements() */
+static xbox_achievement_t *s_xbox_achievements = NULL;
 
 /* -------------------------------------------------------------------------
  * xbox_subscribe_* — called by monitoring_service during monitoring_start()
@@ -75,7 +78,7 @@ const game_t *get_current_game(void) {
     return NULL;
 }
 const xbox_achievement_t *get_current_game_achievements(void) {
-    return NULL;
+    return s_xbox_achievements;
 }
 
 /* -------------------------------------------------------------------------
@@ -129,6 +132,11 @@ void mock_xbox_monitor_set_identity(xbox_identity_t *identity) {
     s_xbox_identity = identity; /* Takes ownership. */
 }
 
+void mock_xbox_monitor_set_achievements(xbox_achievement_t *achievements) {
+    xbox_free_achievement(&s_xbox_achievements);
+    s_xbox_achievements = achievements; /* Takes ownership. */
+}
+
 void mock_xbox_monitor_fire_connection_changed(bool connected, const char *error_message) {
     if (s_cb_connection_changed)
         s_cb_connection_changed(connected, error_message);
@@ -144,8 +152,15 @@ void mock_xbox_monitor_fire_session_ready(void) {
         s_cb_session_ready();
 }
 
+void mock_xbox_monitor_fire_achievements_progressed(const gamerscore_t                *gamerscore,
+                                                     const xbox_achievement_progress_t *progress) {
+    if (s_cb_achievements_progressed)
+        s_cb_achievements_progressed(gamerscore, progress);
+}
+
 void mock_xbox_monitor_reset(void) {
     free_identity(&s_xbox_identity);
+    xbox_free_achievement(&s_xbox_achievements);
     s_cb_connection_changed      = NULL;
     s_cb_game_played             = NULL;
     s_cb_achievements_progressed = NULL;

--- a/test/stubs/integrations/xbox_monitor_stub.h
+++ b/test/stubs/integrations/xbox_monitor_stub.h
@@ -64,7 +64,7 @@ void mock_xbox_monitor_fire_session_ready(void);
  * Invokes the callback registered via xbox_subscribe_achievements_progressed().
  */
 void mock_xbox_monitor_fire_achievements_progressed(const gamerscore_t                *gamerscore,
-                                                     const xbox_achievement_progress_t *progress);
+                                                    const xbox_achievement_progress_t *progress);
 
 /**
  * @brief Reset all stub state (callbacks, stored identity, etc.).

--- a/test/stubs/integrations/xbox_monitor_stub.h
+++ b/test/stubs/integrations/xbox_monitor_stub.h
@@ -10,6 +10,17 @@
 
 #include "common/game.h"
 #include "integrations/xbox/xbox_monitor.h"
+#include "integrations/xbox/contracts/xbox_achievement.h"
+
+// ...existing code...
+
+/**
+ * @brief Set the xbox_achievements that get_current_game_achievements() will return.
+ *
+ * The stub takes ownership of the provided list; pass NULL to make the
+ * stub return NULL (simulates no loaded achievements).
+ */
+void mock_xbox_monitor_set_achievements(xbox_achievement_t *achievements);
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +57,14 @@ void mock_xbox_monitor_fire_game_played(const game_t *game);
  * thread finishes before the game-played notification returns.
  */
 void mock_xbox_monitor_fire_session_ready(void);
+
+/**
+ * @brief Simulate an Xbox achievement progress event.
+ *
+ * Invokes the callback registered via xbox_subscribe_achievements_progressed().
+ */
+void mock_xbox_monitor_fire_achievements_progressed(const gamerscore_t                *gamerscore,
+                                                     const xbox_achievement_progress_t *progress);
 
 /**
  * @brief Reset all stub state (callbacks, stored identity, etc.).

--- a/test/test_monitoring_service.c
+++ b/test/test_monitoring_service.c
@@ -108,18 +108,16 @@ static void fill_retro_achievement(retro_achievement_t *a, uint32_t id, const ch
     strncpy(a->status, status, sizeof(a->status) - 1);
 }
 
-static xbox_achievement_progress_t *make_xbox_achievement_progress(const char *id,
-                                                                    const char *progress_state,
-                                                                    const char *current,
-                                                                    const char *target) {
+static xbox_achievement_progress_t *make_xbox_achievement_progress(const char *id, const char *progress_state,
+                                                                   const char *current, const char *target) {
     xbox_achievement_progress_t *progress = bzalloc(sizeof(xbox_achievement_progress_t));
-    progress->service_config_id            = bstrdup("00000000-0000-0000-0000-0000700a1e17");
-    progress->id                           = bstrdup(id);
-    progress->progress_state               = progress_state ? bstrdup(progress_state) : NULL;
-    progress->current                      = current ? bstrdup(current) : NULL;
-    progress->target                       = target ? bstrdup(target) : NULL;
-    progress->unlocked_timestamp           = 0;
-    progress->next                         = NULL;
+    progress->service_config_id           = bstrdup("00000000-0000-0000-0000-0000700a1e17");
+    progress->id                          = bstrdup(id);
+    progress->progress_state              = progress_state ? bstrdup(progress_state) : NULL;
+    progress->current                     = current ? bstrdup(current) : NULL;
+    progress->target                      = target ? bstrdup(target) : NULL;
+    progress->unlocked_timestamp          = 0;
+    progress->next                        = NULL;
     return progress;
 }
 
@@ -136,12 +134,12 @@ static void free_xbox_achievement_progress(xbox_achievement_progress_t **progres
 }
 
 static xbox_achievement_t *make_xbox_achievement(const char *id, const char *name, const char *progress_state) {
-    xbox_achievement_t *a   = bzalloc(sizeof(xbox_achievement_t));
-    a->id                   = bstrdup(id);
-    a->name                 = bstrdup(name);
-    a->progress_state       = bstrdup(progress_state);
-    a->service_config_id    = bstrdup("00000000-0000-0000-0000-0000700a1e17");
-    a->unlocked_timestamp   = 0;
+    xbox_achievement_t *a = bzalloc(sizeof(xbox_achievement_t));
+    a->id                 = bstrdup(id);
+    a->name               = bstrdup(name);
+    a->progress_state     = bstrdup(progress_state);
+    a->service_config_id  = bstrdup("00000000-0000-0000-0000-0000700a1e17");
+    a->unlocked_timestamp = 0;
     return a;
 }
 
@@ -778,11 +776,11 @@ static void monitoring_achievements__xbox_progress_update_non_zero__measured_pro
     s_session_ready_cb_count = 0;
 
     /* Fire progress update with non-zero current value */
-    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
-        "achievement-1", /* id — matches the seeded achievement */
-        "InProgress",    /* progress_state */
-        "42",            /* current */
-        "100"            /* target */
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress("achievement-1", /* id — matches the seeded
+                                                                                               achievement */
+                                                                           "InProgress",    /* progress_state */
+                                                                           "42",            /* current */
+                                                                           "100"            /* target */
     );
     mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
     free_xbox_achievement_progress(&progress);
@@ -813,11 +811,11 @@ static void monitoring_achievements__xbox_progress_update_zero_current__measured
     s_session_ready_cb_count = 0;
 
     /* Fire progress update with current="0" */
-    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
-        "achievement-1", /* id */
-        "InProgress",    /* progress_state */
-        "0",             /* current — zero should not produce a progress string */
-        "100"            /* target */
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress("achievement-1", /* id */
+                                                                           "InProgress",    /* progress_state */
+                                                                           "0", /* current — zero should not produce a
+                                                                                   progress string */
+                                                                           "100" /* target */
     );
     mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
     free_xbox_achievement_progress(&progress);
@@ -848,11 +846,12 @@ static void monitoring_achievements__xbox_progress_update_achieved__achievements
     s_session_ready_cb_count        = 0;
     s_achievements_changed_cb_count = 0;
 
-    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
-        "achievement-1", /* id — matches the seeded achievement */
-        "Achieved",      /* progress_state — triggers a full rebuild */
-        "100",           /* current */
-        "100"            /* target */
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress("achievement-1", /* id — matches the seeded
+                                                                                               achievement */
+                                                                           "Achieved", /* progress_state — triggers a
+                                                                                          full rebuild */
+                                                                           "100",      /* current */
+                                                                           "100"       /* target */
     );
     mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
     free_xbox_achievement_progress(&progress);
@@ -902,11 +901,10 @@ static void monitoring_achievements__xbox_progress_update_no_identity__early_ret
     s_achievements_changed_cb_count = 0;
 
     /* Fire progress update */
-    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
-        "achievement-1", /* id */
-        "InProgress",    /* progress_state */
-        "42",            /* current */
-        "100"            /* target */
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress("achievement-1", /* id */
+                                                                           "InProgress",    /* progress_state */
+                                                                           "42",            /* current */
+                                                                           "100"            /* target */
     );
     mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
     free_xbox_achievement_progress(&progress);

--- a/test/test_monitoring_service.c
+++ b/test/test_monitoring_service.c
@@ -813,8 +813,8 @@ static void monitoring_achievements__xbox_progress_update_zero_current__measured
     /* Fire progress update with current="0" */
     xbox_achievement_progress_t *progress = make_xbox_achievement_progress("achievement-1", /* id */
                                                                            "InProgress",    /* progress_state */
-                                                                           "0", /* current — zero should not produce a
-                                                                                   progress string */
+                                                                           "0",  /* current — zero should not produce a
+                                                                                    progress string */
                                                                            "100" /* target */
     );
     mock_xbox_monitor_fire_achievements_progressed(NULL, progress);

--- a/test/test_monitoring_service.c
+++ b/test/test_monitoring_service.c
@@ -56,6 +56,7 @@
 #include "integrations/xbox/entities/xbox_identity.h"
 #include "common/game.h"
 #include "common/token.h"
+#include "common/memory.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -105,6 +106,43 @@ static void fill_retro_achievement(retro_achievement_t *a, uint32_t id, const ch
     a->points = 10;
     strncpy(a->name, name, sizeof(a->name) - 1);
     strncpy(a->status, status, sizeof(a->status) - 1);
+}
+
+static xbox_achievement_progress_t *make_xbox_achievement_progress(const char *id,
+                                                                    const char *progress_state,
+                                                                    const char *current,
+                                                                    const char *target) {
+    xbox_achievement_progress_t *progress = bzalloc(sizeof(xbox_achievement_progress_t));
+    progress->service_config_id            = bstrdup("00000000-0000-0000-0000-0000700a1e17");
+    progress->id                           = bstrdup(id);
+    progress->progress_state               = progress_state ? bstrdup(progress_state) : NULL;
+    progress->current                      = current ? bstrdup(current) : NULL;
+    progress->target                       = target ? bstrdup(target) : NULL;
+    progress->unlocked_timestamp           = 0;
+    progress->next                         = NULL;
+    return progress;
+}
+
+static void free_xbox_achievement_progress(xbox_achievement_progress_t **progress) {
+    if (!progress || !*progress)
+        return;
+    xbox_achievement_progress_t *p = *progress;
+    free_memory((void **)&p->service_config_id);
+    free_memory((void **)&p->id);
+    free_memory((void **)&p->progress_state);
+    free_memory((void **)&p->current);
+    free_memory((void **)&p->target);
+    free_memory((void **)progress);
+}
+
+static xbox_achievement_t *make_xbox_achievement(const char *id, const char *name, const char *progress_state) {
+    xbox_achievement_t *a   = bzalloc(sizeof(xbox_achievement_t));
+    a->id                   = bstrdup(id);
+    a->name                 = bstrdup(name);
+    a->progress_state       = bstrdup(progress_state);
+    a->service_config_id    = bstrdup("00000000-0000-0000-0000-0000700a1e17");
+    a->unlocked_timestamp   = 0;
+    return a;
 }
 
 /* -------------------------------------------------------------------------
@@ -718,6 +756,165 @@ static void monitoring_session_ready__xbox_session_ready_with_game__fired(void) 
     TEST_ASSERT_EQUAL_INT(1, s_session_ready_cb_count);
 }
 
+/* =========================================================================
+ * Achievement progress updates — Xbox
+ * ====================================================================== */
+
+/* 26. Xbox achievement progress update with non-zero current value → measured_progress
+ *     is patched in-place on the cached achievement (cycle is NOT reset). */
+static void monitoring_achievements__xbox_progress_update_non_zero__measured_progress_set(void) {
+    mock_xbox_monitor_set_identity(make_xbox_identity("MasterChief"));
+    mock_xbox_monitor_fire_connection_changed(true, NULL);
+
+    /* Seed one achievement so g_current_achievements is non-NULL after session_ready. */
+    mock_xbox_monitor_set_achievements(make_xbox_achievement("achievement-1", "Stop Hitting Yourself", "NotStarted"));
+
+    game_t *xbox_game = make_xbox_game("game-1", "Halo Infinite");
+    mock_xbox_monitor_fire_game_played(xbox_game);
+    free_game(&xbox_game);
+
+    mock_xbox_monitor_fire_session_ready();
+
+    s_session_ready_cb_count = 0;
+
+    /* Fire progress update with non-zero current value */
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
+        "achievement-1", /* id — matches the seeded achievement */
+        "InProgress",    /* progress_state */
+        "42",            /* current */
+        "100"            /* target */
+    );
+    mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
+    free_xbox_achievement_progress(&progress);
+
+    /* The cycle must NOT have been reset. */
+    TEST_ASSERT_EQUAL_INT(0, s_session_ready_cb_count);
+
+    /* measured_progress must have been patched in-place to "42/100". */
+    const achievement_t *a = monitoring_get_current_game_achievements();
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_EQUAL_STRING("42/100", a->measured_progress);
+}
+
+/* 27. Xbox achievement progress update with current="0" → measured_progress stays NULL
+ *     (a zero value is not displayed). */
+static void monitoring_achievements__xbox_progress_update_zero_current__measured_progress_not_set(void) {
+    mock_xbox_monitor_set_identity(make_xbox_identity("MasterChief"));
+    mock_xbox_monitor_fire_connection_changed(true, NULL);
+
+    mock_xbox_monitor_set_achievements(make_xbox_achievement("achievement-1", "Stop Hitting Yourself", "NotStarted"));
+
+    game_t *xbox_game = make_xbox_game("game-1", "Halo Infinite");
+    mock_xbox_monitor_fire_game_played(xbox_game);
+    free_game(&xbox_game);
+
+    mock_xbox_monitor_fire_session_ready();
+
+    s_session_ready_cb_count = 0;
+
+    /* Fire progress update with current="0" */
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
+        "achievement-1", /* id */
+        "InProgress",    /* progress_state */
+        "0",             /* current — zero should not produce a progress string */
+        "100"            /* target */
+    );
+    mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
+    free_xbox_achievement_progress(&progress);
+
+    TEST_ASSERT_EQUAL_INT(0, s_session_ready_cb_count);
+
+    /* measured_progress must remain NULL when current is "0". */
+    const achievement_t *a = monitoring_get_current_game_achievements();
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NULL(a->measured_progress);
+}
+
+/* 28. Xbox achievement progressed to "Achieved" → achievements list is rebuilt
+ *     and achievements_changed fires to reset the display cycle.
+ *     session_ready must NOT fire (it would wrongly imply icons were re-prefetched). */
+static void monitoring_achievements__xbox_progress_update_achieved__achievements_changed_fired(void) {
+    mock_xbox_monitor_set_identity(make_xbox_identity("MasterChief"));
+    mock_xbox_monitor_fire_connection_changed(true, NULL);
+
+    mock_xbox_monitor_set_achievements(make_xbox_achievement("achievement-1", "Stop Hitting Yourself", "InProgress"));
+
+    game_t *xbox_game = make_xbox_game("game-1", "Halo Infinite");
+    mock_xbox_monitor_fire_game_played(xbox_game);
+    free_game(&xbox_game);
+
+    mock_xbox_monitor_fire_session_ready();
+
+    s_session_ready_cb_count        = 0;
+    s_achievements_changed_cb_count = 0;
+
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
+        "achievement-1", /* id — matches the seeded achievement */
+        "Achieved",      /* progress_state — triggers a full rebuild */
+        "100",           /* current */
+        "100"            /* target */
+    );
+    mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
+    free_xbox_achievement_progress(&progress);
+
+    /* achievements_changed must fire to reset the display cycle. */
+    TEST_ASSERT_EQUAL_INT(1, s_achievements_changed_cb_count);
+    /* session_ready must NOT fire — images were already downloaded. */
+    TEST_ASSERT_EQUAL_INT(0, s_session_ready_cb_count);
+}
+
+/* 29. Xbox achievement progress update with NULL progress → nothing happens. */
+static void monitoring_achievements__xbox_progress_update_null__no_effect(void) {
+    /* Set up Xbox game */
+    mock_xbox_monitor_set_identity(make_xbox_identity("MasterChief"));
+    mock_xbox_monitor_fire_connection_changed(true, NULL);
+
+    game_t *xbox_game = make_xbox_game("game-1", "Halo Infinite");
+    mock_xbox_monitor_fire_game_played(xbox_game);
+    free_game(&xbox_game);
+
+    mock_xbox_monitor_fire_session_ready();
+
+    s_identity_cb_count             = 0;
+    s_session_ready_cb_count        = 0;
+    s_achievements_changed_cb_count = 0;
+
+    /* Fire progress update with NULL progress */
+    mock_xbox_monitor_fire_achievements_progressed(NULL, NULL);
+
+    /* Nothing should happen */
+    TEST_ASSERT_EQUAL_INT(0, s_session_ready_cb_count);
+}
+
+/* 30. Xbox achievement progress update without identity → callback returns early. */
+static void monitoring_achievements__xbox_progress_update_no_identity__early_return(void) {
+    /* Connect but do NOT set identity */
+    mock_xbox_monitor_fire_connection_changed(true, NULL);
+
+    game_t *xbox_game = make_xbox_game("game-1", "Halo Infinite");
+    mock_xbox_monitor_fire_game_played(xbox_game);
+    free_game(&xbox_game);
+
+    mock_xbox_monitor_fire_session_ready();
+
+    s_identity_cb_count             = 0;
+    s_session_ready_cb_count        = 0;
+    s_achievements_changed_cb_count = 0;
+
+    /* Fire progress update */
+    xbox_achievement_progress_t *progress = make_xbox_achievement_progress(
+        "achievement-1", /* id */
+        "InProgress",    /* progress_state */
+        "42",            /* current */
+        "100"            /* target */
+    );
+    mock_xbox_monitor_fire_achievements_progressed(NULL, progress);
+    free_xbox_achievement_progress(&progress);
+
+    /* Nothing should happen because there's no identity */
+    TEST_ASSERT_EQUAL_INT(0, s_session_ready_cb_count);
+}
+
 /* -------------------------------------------------------------------------
  * Test runner
  * ---------------------------------------------------------------------- */
@@ -761,6 +958,13 @@ int main(void) {
     RUN_TEST(monitoring_achievements__xbox_session_ready_without_game__achievements_not_overwritten);
     RUN_TEST(monitoring_session_ready__xbox_session_ready_without_game__not_fired);
     RUN_TEST(monitoring_session_ready__xbox_session_ready_with_game__fired);
+
+    /* Achievement progress updates — Xbox */
+    RUN_TEST(monitoring_achievements__xbox_progress_update_non_zero__measured_progress_set);
+    RUN_TEST(monitoring_achievements__xbox_progress_update_zero_current__measured_progress_not_set);
+    RUN_TEST(monitoring_achievements__xbox_progress_update_achieved__achievements_changed_fired);
+    RUN_TEST(monitoring_achievements__xbox_progress_update_null__no_effect);
+    RUN_TEST(monitoring_achievements__xbox_progress_update_no_identity__early_return);
 
     return UNITY_END();
 }


### PR DESCRIPTION
This pull request implements support for tracking and displaying Xbox achievement progress in real time, including partial progress (e.g., "42/100") for achievements that are not yet unlocked. It adds new fields to Xbox achievement and progress structures, updates the logic to patch and display measured progress in-place without resetting the achievement cycle, and ensures UI elements reflect these updates immediately. Additionally, it improves session state handling for RetroArch achievements and refines text source updates for better visual feedback.

**Xbox Achievement Progress Tracking:**
* Added `progression_current` and `progression_target` fields to `xbox_achievement_t` and `current`/`target` to `xbox_achievement_progress_t` to store partial progress values, updated parsing, copying, and freeing logic to handle these fields.
* Implemented `xbox_session_progress_achievement` to update in-progress achievements and log their state, and integrated it with the Xbox monitor event flow.

**Achievement Cycle and Display Updates:**
* Added `achievement_cycle_refresh_current` to re-notify subscribers after in-place field updates (e.g., measured progress), ensuring the UI updates without resetting the cycle.
* Modified the achievement display logic to include measured progress in the achievement name string when available.
* Updated `text_source_update_text` to propagate the active color flag even when the text does not change, ensuring visual state changes are reflected.

**Session and State Handling Improvements:**
* Improved session-ready logic for RetroArch achievements to avoid starting the cycle with an empty list, preventing initial blank states.
* Updated Xbox session unlock logic to handle null unlock timestamps robustly and clear in-progress tracking when an achievement is unlocked.

**Codebase Maintenance:**
* Added missing includes and source file references for new functionality.
* Minor docstring and logging improvements for clarity.

These changes ensure that Xbox achievement progress is tracked accurately, displayed responsively, and managed efficiently throughout the session lifecycle.